### PR TITLE
Events refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,6 @@ set(libqmatrixclient_SRCS
    logging.cpp
    room.cpp
    user.cpp
-   state.cpp
    settings.cpp
    events/event.cpp
    events/roommessageevent.cpp
@@ -61,7 +60,6 @@ set(libqmatrixclient_SRCS
    events/roomtopicevent.cpp
    events/typingevent.cpp
    events/receiptevent.cpp
-   events/unknownevent.cpp
    jobs/basejob.cpp
    jobs/checkauthmethods.cpp
    jobs/passwordlogin.cpp

--- a/connection.cpp
+++ b/connection.cpp
@@ -191,7 +191,7 @@ void Connection::postMessage(Room* room, const QString& type, const QString& mes
     callApi<PostMessageJob>(room->id(), type, message);
 }
 
-PostReceiptJob* Connection::postReceipt(Room* room, Event* event) const
+PostReceiptJob* Connection::postReceipt(Room* room, RoomEvent* event) const
 {
     return callApi<PostReceiptJob>(room->id(), event->id());
 }

--- a/connection.h
+++ b/connection.h
@@ -26,7 +26,7 @@ namespace QMatrixClient
 {
     class Room;
     class User;
-    class Event;
+    class RoomEvent;
     class ConnectionPrivate;
     class ConnectionData;
 
@@ -61,7 +61,8 @@ namespace QMatrixClient
             Q_INVOKABLE virtual void postMessage(Room* room, const QString& type,
                                                  const QString& message) const;
             /** @deprecated Use callApi<PostReceiptJob>() or Room::postReceipt() instead */
-            Q_INVOKABLE virtual PostReceiptJob* postReceipt( Room* room, Event* event ) const;
+            Q_INVOKABLE virtual PostReceiptJob* postReceipt(Room* room,
+                                                            RoomEvent* event) const;
             Q_INVOKABLE virtual JoinRoomJob* joinRoom(const QString& roomAlias);
             /** @deprecated Use callApi<LeaveRoomJob>() or Room::leaveRoom() instead */
             Q_INVOKABLE virtual void leaveRoom( Room* room );

--- a/events/event.cpp
+++ b/events/event.cpp
@@ -18,9 +18,6 @@
 
 #include "event.h"
 
-#include <QtCore/QJsonArray>
-#include <QtCore/QJsonDocument>
-
 #include "roommessageevent.h"
 #include "roomnameevent.h"
 #include "roomaliasesevent.h"
@@ -31,120 +28,101 @@
 #include "receiptevent.h"
 #include "unknownevent.h"
 #include "logging.h"
-#include "util.h"
+
+#include <QtCore/QJsonDocument>
 
 using namespace QMatrixClient;
 
-class Event::Private
+Event::Event(Type type, const QJsonObject& rep)
+    : _type(type), _originalJson(rep)
 {
-    public:
-        EventType type;
-        QString id;
-        QDateTime timestamp;
-        QString roomId;
-        QString senderId;
-        QString originalJson;
-};
-
-Event::Event(EventType type)
-    : d(new Private)
-{
-    d->type = type;
+    if (!rep.contains("content"))
+    {
+        qCWarning(EVENTS) << "Event without 'content' node";
+        qCWarning(EVENTS) << formatJson << rep;
+    }
 }
 
-Event::~Event()
+QByteArray Event::originalJson() const
 {
-    delete d;
+    return QJsonDocument(_originalJson).toJson();
 }
 
-EventType Event::type() const
+QDateTime Event::toTimestamp(const QJsonValue& v)
 {
-    return d->type;
+    Q_ASSERT(v.isDouble());
+    return QDateTime::fromMSecsSinceEpoch(
+            static_cast<long long int>(v.toDouble()), Qt::UTC);
 }
 
-QString Event::id() const
+QStringList Event::toStringList(const QJsonValue& v)
 {
-    return d->id;
+    Q_ASSERT(v.isArray());
+
+    QStringList l;
+    for( const QJsonValue& e : v.toArray() )
+        l.push_back(e.toString());
+    return l;
 }
 
-QDateTime Event::timestamp() const
+const QJsonObject Event::contentJson() const
 {
-    return d->timestamp;
-}
-
-QString Event::roomId() const
-{
-    return d->roomId;
-}
-
-QString Event::senderId() const
-{
-    return d->senderId;
-}
-
-QString Event::originalJson() const
-{
-    return d->originalJson;
+    return _originalJson["content"].toObject();
 }
 
 template <typename EventT>
-EventT* make(const QJsonObject& obj)
+EventT* make(const QJsonObject& o)
 {
-    return EventT::fromJson(obj);
+    return new EventT(o);
 }
 
 Event* Event::fromJson(const QJsonObject& obj)
 {
+    // Check more specific event types first
+    if (auto e = RoomEvent::fromJson(obj))
+        return e;
+
     return dispatch<Event*>(obj).to(obj["type"].toString(),
-            "m.room.message", &make<RoomMessageEvent>,
-            "m.room.name", &make<RoomNameEvent>,
-            "m.room.aliases", &make<RoomAliasesEvent>,
-            "m.room.canonical_alias", &make<RoomCanonicalAliasEvent>,
-            "m.room.member", &make<RoomMemberEvent>,
-            "m.room.topic", &make<RoomTopicEvent>,
-            "m.typing", &make<TypingEvent>,
-            "m.receipt", &make<ReceiptEvent>,
-            /* Insert new event types BEFORE this line */
-            &make<UnknownEvent>
-        );
+            "m.typing", make<TypingEvent>,
+            "m.receipt", make<ReceiptEvent>,
+            /* Insert new event types (except room events) BEFORE this line */
+            nullptr
+            );
 }
 
-bool Event::parseJson(const QJsonObject& obj)
+RoomEvent::RoomEvent(Type type, const QJsonObject& rep)
+    : Event(type, rep), _id(rep["event_id"].toString())
+    , _serverTimestamp(toTimestamp(rep["origin_server_ts"]))
+    , _roomId(rep["room_id"].toString())
+    , _senderId(rep["sender"].toString())
 {
-    d->originalJson = QString::fromUtf8(QJsonDocument(obj).toJson());
-    d->id = obj.value("event_id").toString();
-    d->roomId = obj.value("room_id").toString();
-    d->senderId = obj.value("sender").toString();
-    bool correct = (d->type != EventType::Unknown);
-    if ( d->type != EventType::Typing &&
-         d->type != EventType::Receipt )
+    if (_id.isEmpty())
     {
-        if (d->id.isEmpty())
-        {
-            correct = false;
-            qCDebug(EVENTS) << "Event: can't find event_id; event dump follows";
-            qCDebug(EVENTS) << formatJson << obj;
-        }
-        if( obj.contains("origin_server_ts") )
-        {
-            d->timestamp = QDateTime::fromMSecsSinceEpoch(
-                static_cast<qint64>(obj.value("origin_server_ts").toDouble()), Qt::UTC );
-        }
-        else if (d->type != EventType::Unknown)
-        {
-            correct = false;
-            qCDebug(EVENTS) << "Event: can't find ts; event dump follows";
-            qCDebug(EVENTS) << formatJson << obj;
-        }
+        qCWarning(EVENTS) << "Can't find event_id in a room event";
+        qCWarning(EVENTS) << formatJson << rep;
     }
-    return correct;
+    if (!rep.contains("origin_server_ts"))
+    {
+        qCWarning(EVENTS) << "Event: can't find server timestamp in a room event";
+        qCWarning(EVENTS) << formatJson << rep;
+    }
+    if (_senderId.isEmpty())
+    {
+        qCWarning(EVENTS) << "user_id not found in a room event";
+        qCWarning(EVENTS) << formatJson << rep;
+    }
 }
 
-Events QMatrixClient::eventsFromJson(const QJsonArray& json)
+RoomEvent* RoomEvent::fromJson(const QJsonObject& obj)
 {
-    Events evs;
-    evs.reserve(json.size());
-    for (auto event: json)
-        evs.push_back(Event::fromJson(event.toObject()));
-    return evs;
+    return dispatch<RoomEvent*>(obj).to(obj["type"].toString(),
+            "m.room.message", make<RoomMessageEvent>,
+            "m.room.name", make<RoomNameEvent>,
+            "m.room.aliases", make<RoomAliasesEvent>,
+            "m.room.canonical_alias", make<RoomCanonicalAliasEvent>,
+            "m.room.member", make<RoomMemberEvent>,
+            "m.room.topic", make<RoomTopicEvent>,
+            /* Insert new ROOM event types BEFORE this line */
+            nullptr
+        );
 }

--- a/events/event.cpp
+++ b/events/event.cpp
@@ -87,27 +87,26 @@ QString Event::originalJson() const
     return d->originalJson;
 }
 
-template <typename T>
-Event* make(const QJsonObject& obj)
+template <typename EventT>
+EventT* make(const QJsonObject& obj)
 {
-    return T::fromJson(obj);
+    return EventT::fromJson(obj);
 }
 
 Event* Event::fromJson(const QJsonObject& obj)
 {
-    auto delegate = lookup(obj.value("type").toString(),
-            "m.room.message", make<RoomMessageEvent>,
-            "m.room.name", make<RoomNameEvent>,
-            "m.room.aliases", make<RoomAliasesEvent>,
-            "m.room.canonical_alias", make<RoomCanonicalAliasEvent>,
-            "m.room.member", make<RoomMemberEvent>,
-            "m.room.topic", make<RoomTopicEvent>,
-            "m.typing", make<TypingEvent>,
-            "m.receipt", make<ReceiptEvent>,
+    return dispatch<Event*>(obj).to(obj["type"].toString(),
+            "m.room.message", &make<RoomMessageEvent>,
+            "m.room.name", &make<RoomNameEvent>,
+            "m.room.aliases", &make<RoomAliasesEvent>,
+            "m.room.canonical_alias", &make<RoomCanonicalAliasEvent>,
+            "m.room.member", &make<RoomMemberEvent>,
+            "m.room.topic", &make<RoomTopicEvent>,
+            "m.typing", &make<TypingEvent>,
+            "m.receipt", &make<ReceiptEvent>,
             /* Insert new event types BEFORE this line */
-            make<UnknownEvent>
+            &make<UnknownEvent>
         );
-    return delegate(obj);
 }
 
 bool Event::parseJson(const QJsonObject& obj)

--- a/events/event.h
+++ b/events/event.h
@@ -21,43 +21,92 @@
 #include <QtCore/QString>
 #include <QtCore/QDateTime>
 #include <QtCore/QJsonObject>
-#include <QtCore/QVector>
+#include <QtCore/QJsonArray>
 
-class QJsonArray;
+#include "util.h"
 
 namespace QMatrixClient
 {
-    enum class EventType
-    {
-        RoomMessage, RoomName, RoomAliases, RoomCanonicalAlias,
-        RoomMember, RoomTopic, Typing, Receipt, Unknown
-    };
-
     class Event
     {
+            Q_GADGET
         public:
-            explicit Event(EventType type);
-            Event(Event&) = delete;
-            virtual ~Event();
-            
-            EventType type() const;
-            QString id() const;
-            QDateTime timestamp() const;
-            QString roomId() const;
-            QString senderId() const;
-            // only for debug purposes!
-            QString originalJson() const;
+            enum class Type
+            {
+                RoomMessage, RoomName, RoomAliases, RoomCanonicalAlias,
+                RoomMember, RoomTopic, Typing, Receipt, Unknown
+            };
+
+            explicit Event(Type type, const QJsonObject& rep);
+            Event(const Event&) = delete;
+
+            Type type() const { return _type; }
+            QByteArray originalJson() const;
+
+            // Every event also has a "content" object but since its structure is
+            // different for different types, we're implementing it per-event type
+            // (and in most cases it will be a combination of other fields
+            // instead of "content" field).
 
             static Event* fromJson(const QJsonObject& obj);
-            
-        protected:
-            bool parseJson(const QJsonObject& obj);
-        
-        private:
-            class Private;
-            Private* d;
-    };
-    using Events = QVector<Event*>;
 
-    Events eventsFromJson(const QJsonArray& json);
-}
+        protected:
+            static QDateTime toTimestamp(const QJsonValue& v);
+            static QStringList toStringList(const QJsonValue& v);
+
+            const QJsonObject contentJson() const;
+
+        private:
+            Type _type;
+            QJsonObject _originalJson;
+
+            REGISTER_ENUM(Type)
+    };
+    using EventType = Event::Type;
+    template <typename EventT>
+    using EventsBatch = std::vector<EventT*>;
+    using Events = EventsBatch<Event>;
+
+    template <typename BaseEventT>
+    BaseEventT* makeEvent(const QJsonObject& obj)
+    {
+        if (auto e = BaseEventT::fromJson(obj))
+            return e;
+
+        return new BaseEventT(EventType::Unknown, obj);
+    }
+
+    template <typename BaseEventT = Event,
+              typename BatchT = EventsBatch<BaseEventT> >
+    BatchT makeEvents(const QJsonArray& objs)
+    {
+        BatchT evs;
+        // The below line accommodates the difference in size types of
+        // STL and Qt containers.
+        evs.reserve(static_cast<typename BatchT::size_type>(objs.size()));
+        for (auto obj: objs)
+            evs.push_back(makeEvent<BaseEventT>(obj.toObject()));
+        return evs;
+    }
+
+    class RoomEvent : public Event
+    {
+        public:
+            RoomEvent(Type type, const QJsonObject& rep);
+
+            const QString& id() const          { return _id; }
+            const QDateTime& timestamp() const { return _serverTimestamp; }
+            const QString& roomId() const      { return _roomId; }
+            const QString& senderId() const    { return _senderId; }
+
+            // "Static override" of the one in Event
+            static RoomEvent* fromJson(const QJsonObject& obj);
+
+        private:
+            QString _id;
+            QDateTime _serverTimestamp;
+            QString _roomId;
+            QString _senderId;
+    };
+    using RoomEvents = EventsBatch<RoomEvent>;
+}  // namespace QMatrixClient

--- a/events/receiptevent.h
+++ b/events/receiptevent.h
@@ -22,32 +22,29 @@
 
 namespace QMatrixClient
 {
-    class Receipt
+    struct Receipt
     {
-        public:
-            QString userId;
-            QDateTime timestamp;
+        QString userId;
+        QDateTime timestamp;
     };
-}
-Q_DECLARE_TYPEINFO(QMatrixClient::Receipt, Q_MOVABLE_TYPE);
-
-namespace QMatrixClient
-{
-    using Receipts = QVector<Receipt>;
-    using EventsToReceipts = QVector< QPair<QString, Receipts> >;
+    struct ReceiptsForEvent
+    {
+        QString evtId;
+        std::vector<Receipt> receipts;
+    };
+    using EventsWithReceipts = std::vector<ReceiptsForEvent>;
 
     class ReceiptEvent: public Event
     {
         public:
-            ReceiptEvent();
-            virtual ~ReceiptEvent();
+            explicit ReceiptEvent(const QJsonObject& obj);
 
-            EventsToReceipts events() const;
-
-            static ReceiptEvent* fromJson(const QJsonObject& obj);
+            EventsWithReceipts eventsWithReceipts() const
+            { return _eventsWithReceipts; }
 
         private:
-            class Private;
-            Private* d;
+            EventsWithReceipts _eventsWithReceipts;
+
+            static constexpr const char * jsonType = "m.receipt";
     };
-}
+}  // namespace QMatrixClient

--- a/events/roomaliasesevent.cpp
+++ b/events/roomaliasesevent.cpp
@@ -34,44 +34,10 @@
 
 #include "roomaliasesevent.h"
 
-#include "logging.h"
-
-#include <QtCore/QJsonArray>
-
 using namespace QMatrixClient;
 
-class RoomAliasesEvent::Private
-{
-    public:
-        QStringList aliases;
-};
+RoomAliasesEvent::RoomAliasesEvent(const QJsonObject& obj)
+    : RoomEvent(Type::RoomAliases, obj)
+    , _aliases(toStringList(contentJson()["aliases"]))
+{ }
 
-RoomAliasesEvent::RoomAliasesEvent()
-    : Event(EventType::RoomAliases)
-    , d(new Private)
-{
-}
-
-RoomAliasesEvent::~RoomAliasesEvent()
-{
-    delete d;
-}
-
-QStringList RoomAliasesEvent::aliases() const
-{
-    return d->aliases;
-}
-
-RoomAliasesEvent* RoomAliasesEvent::fromJson(const QJsonObject& obj)
-{
-    RoomAliasesEvent* e = new RoomAliasesEvent();
-    e->parseJson(obj);
-    const QJsonObject contents = obj.value("content").toObject();
-    const QJsonArray aliases = contents.value("aliases").toArray();
-    for( const QJsonValue& alias : aliases )
-    {
-        e->d->aliases << alias.toString();
-    }
-    qCDebug(EVENTS) << "RoomAliasesEvent:" << e->d->aliases;
-    return e;
-}

--- a/events/roomaliasesevent.h
+++ b/events/roomaliasesevent.h
@@ -24,18 +24,14 @@
 
 namespace QMatrixClient
 {
-    class RoomAliasesEvent: public Event
+    class RoomAliasesEvent: public RoomEvent
     {
         public:
-            RoomAliasesEvent();
-            virtual ~RoomAliasesEvent();
+            explicit RoomAliasesEvent(const QJsonObject& obj);
 
-            QStringList aliases() const;
-
-            static RoomAliasesEvent* fromJson(const QJsonObject& obj);
+            QStringList aliases() const { return _aliases; }
 
         private:
-            class Private;
-            Private* d;
+            QStringList _aliases;
     };
-}
+}  // namespace QMatrixClient

--- a/events/roomcanonicalaliasevent.cpp
+++ b/events/roomcanonicalaliasevent.cpp
@@ -19,35 +19,3 @@
 #include "roomcanonicalaliasevent.h"
 
 using namespace QMatrixClient;
-
-class RoomCanonicalAliasEvent::Private
-{
-    public:
-        QString alias;
-};
-
-RoomCanonicalAliasEvent::RoomCanonicalAliasEvent()
-    : Event(EventType::RoomCanonicalAlias)
-    , d(new Private)
-{
-}
-
-RoomCanonicalAliasEvent::~RoomCanonicalAliasEvent()
-{
-    delete d;
-}
-
-QString RoomCanonicalAliasEvent::alias()
-{
-    return d->alias;
-}
-
-RoomCanonicalAliasEvent* RoomCanonicalAliasEvent::fromJson(const QJsonObject& obj)
-{
-    RoomCanonicalAliasEvent* e = new RoomCanonicalAliasEvent();
-    e->parseJson(obj);
-    const QJsonObject contents = obj.value("content").toObject();
-    e->d->alias = contents.value("alias").toString();
-    return e;
-}
-

--- a/events/roomcanonicalaliasevent.h
+++ b/events/roomcanonicalaliasevent.h
@@ -22,18 +22,17 @@
 
 namespace QMatrixClient
 {
-    class RoomCanonicalAliasEvent: public Event
+    class RoomCanonicalAliasEvent : public RoomEvent
     {
         public:
-            RoomCanonicalAliasEvent();
-            virtual ~RoomCanonicalAliasEvent();
+            explicit RoomCanonicalAliasEvent(const QJsonObject& obj)
+                : RoomEvent(Type::RoomCanonicalAlias, obj)
+                , _canonicalAlias(contentJson()["alias"].toString())
+            { }
 
-            QString alias();
-
-            static RoomCanonicalAliasEvent* fromJson(const QJsonObject& obj);
+            QString alias() const { return _canonicalAlias; }
 
         private:
-            class Private;
-            Private* d;
+            QString _canonicalAlias;
     };
-}
+}  // namespace QMatrixClient

--- a/events/roommemberevent.h
+++ b/events/roommemberevent.h
@@ -24,23 +24,26 @@
 
 namespace QMatrixClient
 {
-    enum class MembershipType {Invite, Join, Knock, Leave, Ban};
-
-    class RoomMemberEvent: public Event
+    class RoomMemberEvent: public RoomEvent
     {
+            Q_GADGET
         public:
-            RoomMemberEvent();
-            virtual ~RoomMemberEvent();
+            enum MembershipType : int {Invite = 0, Join, Knock, Leave, Ban};
 
-            MembershipType membership() const;
-            QString userId() const;
-            QString displayName() const;
-            QUrl avatarUrl() const;
+            explicit RoomMemberEvent(const QJsonObject& obj);
 
-            static RoomMemberEvent* fromJson(const QJsonObject& obj);
+            MembershipType membership() const  { return _membership; }
+            const QString& userId() const      { return _userId; }
+            const QString& displayName() const { return _displayName; }
+            const QUrl& avatarUrl() const      { return _avatarUrl; }
 
         private:
-            class Private;
-            Private* d;
+            MembershipType _membership;
+            QString _userId;
+            QString _displayName;
+            QUrl _avatarUrl;
+
+            REGISTER_ENUM(MembershipType)
     };
-}
+    using MembershipType = RoomMemberEvent::MembershipType;
+}  // namespace QMatrixClient

--- a/events/roommessageevent.cpp
+++ b/events/roommessageevent.cpp
@@ -64,16 +64,16 @@ RoomMessageEvent::RoomMessageEvent(const QJsonObject& obj)
         _plainBody = content["body"].toString();
 
         auto factory = lookup(content["msgtype"].toString(),
-                            "m.text", make<CType::Text, TextContent>,
-                            "m.emote", make<CType::Emote, TextContent>,
-                            "m.notice", make<CType::Notice, TextContent>,
-                            "m.image", make<CType::Image, ImageContent>,
-                            "m.file", make<CType::File, FileContent>,
-                            "m.location", make<CType::Location, LocationContent>,
-                            "m.video", makeVideo,
-                            "m.audio", make<CType::Audio, AudioContent>,
+                            "m.text", &make<CType::Text, TextContent>,
+                            "m.emote", &make<CType::Emote, TextContent>,
+                            "m.notice", &make<CType::Notice, TextContent>,
+                            "m.image", &make<CType::Image, ImageContent>,
+                            "m.file", &make<CType::File, FileContent>,
+                            "m.location", &make<CType::Location, LocationContent>,
+                            "m.video", &makeVideo,
+                            "m.audio", &make<CType::Audio, AudioContent>,
                             // Insert new message types before this line
-                            makeUnknown
+                            &makeUnknown
                         );
         std::tie(_msgtype, _content) = factory(content);
     }

--- a/events/roommessageevent.cpp
+++ b/events/roommessageevent.cpp
@@ -120,17 +120,17 @@ RoomMessageEvent* RoomMessageEvent::fromJson(const QJsonObject& obj)
         {
             e->d->plainBody = content["body"].toString();
 
-            auto delegate = lookup(content.value("msgtype").toString(),
-                    "m.text", make<MessageEventType::Text, TextContent>,
-                    "m.emote", make<MessageEventType::Emote, TextContent>,
-                    "m.notice", make<MessageEventType::Notice, TextContent>,
-                    "m.image", make<MessageEventType::Image, ImageContent>,
-                    "m.file", make<MessageEventType::File, FileContent>,
-                    "m.location", make<MessageEventType::Location, LocationContent>,
-                    "m.video", makeVideo,
-                    "m.audio", make<MessageEventType::Audio, AudioContent>,
+            auto delegate = lookup(content["msgtype"].toString(),
+                    "m.text", &make<MessageEventType::Text, TextContent>,
+                    "m.emote", &make<MessageEventType::Emote, TextContent>,
+                    "m.notice", &make<MessageEventType::Notice, TextContent>,
+                    "m.image", &make<MessageEventType::Image, ImageContent>,
+                    "m.file", &make<MessageEventType::File, FileContent>,
+                    "m.location", &make<MessageEventType::Location, LocationContent>,
+                    "m.video", &makeVideo,
+                    "m.audio", &make<MessageEventType::Audio, AudioContent>,
                     // Insert new message types before this line
-                    makeUnknown
+                    &makeUnknown
                 );
             std::tie(e->d->msgtype, e->d->content) = delegate(content);
         }

--- a/events/roomnameevent.cpp
+++ b/events/roomnameevent.cpp
@@ -20,33 +20,3 @@
 
 using namespace QMatrixClient;
 
-class RoomNameEvent::Private
-{
-    public:
-        QString name;
-};
-
-RoomNameEvent::RoomNameEvent() :
-    Event(EventType::RoomName),
-    d(new Private)
-{
-}
-
-RoomNameEvent::~RoomNameEvent()
-{
-    delete d;
-}
-
-QString RoomNameEvent::name() const
-{
-    return d->name;
-}
-
-RoomNameEvent* RoomNameEvent::fromJson(const QJsonObject& obj)
-{
-    RoomNameEvent* e = new RoomNameEvent();
-    e->parseJson(obj);
-    const QJsonObject contents = obj.value("content").toObject();
-    e->d->name = contents.value("name").toString();
-    return e;
-}

--- a/events/roomnameevent.h
+++ b/events/roomnameevent.h
@@ -22,18 +22,17 @@
 
 namespace QMatrixClient
 {
-    class RoomNameEvent : public Event
+    class RoomNameEvent : public RoomEvent
     {
         public:
-            RoomNameEvent();
-            virtual ~RoomNameEvent();
+            explicit RoomNameEvent(const QJsonObject& obj)
+                : RoomEvent(Type::RoomName, obj)
+                , _name(contentJson()["name"].toString())
+            { }
 
-            QString name() const;
-
-            static RoomNameEvent* fromJson(const QJsonObject& obj);
+            QString name() const { return _name; }
 
         private:
-            class Private;
-            Private *d;
+            QString _name{};
     };
-}
+} // namespace QMatrixClient

--- a/events/roomtopicevent.cpp
+++ b/events/roomtopicevent.cpp
@@ -20,32 +20,3 @@
 
 using namespace QMatrixClient;
 
-class RoomTopicEvent::Private
-{
-    public:
-        QString topic;
-};
-
-RoomTopicEvent::RoomTopicEvent()
-    : Event(EventType::RoomTopic)
-    , d(new Private)
-{
-}
-
-RoomTopicEvent::~RoomTopicEvent()
-{
-    delete d;
-}
-
-QString RoomTopicEvent::topic() const
-{
-    return d->topic;
-}
-
-RoomTopicEvent* RoomTopicEvent::fromJson(const QJsonObject& obj)
-{
-    auto e = new RoomTopicEvent();
-    e->parseJson(obj);
-    e->d->topic = obj.value("content").toObject().value("topic").toString();
-    return e;
-}

--- a/events/roomtopicevent.h
+++ b/events/roomtopicevent.h
@@ -22,18 +22,17 @@
 
 namespace QMatrixClient
 {
-    class RoomTopicEvent: public Event
+    class RoomTopicEvent: public RoomEvent
     {
         public:
-            RoomTopicEvent();
-            virtual ~RoomTopicEvent();
+            explicit RoomTopicEvent(const QJsonObject& obj)
+                : RoomEvent(Type::RoomTopic, obj)
+                , _topic(contentJson()["topic"].toString())
+            { }
 
-            QString topic() const;
-
-            static RoomTopicEvent* fromJson(const QJsonObject& obj);
+            QString topic() const { return _topic; }
 
         private:
-            class Private;
-            Private* d;
+            QString _topic;
     };
-}
+}  // namespace QMatrixClient

--- a/events/typingevent.cpp
+++ b/events/typingevent.cpp
@@ -18,43 +18,15 @@
 
 #include "typingevent.h"
 
-#include "logging.h"
-
-#include <QtCore/QJsonArray>
-
 using namespace QMatrixClient;
 
-class TypingEvent::Private
+TypingEvent::TypingEvent(const QJsonObject& obj)
+    : Event(Type::Typing, obj)
 {
-    public:
-        QStringList users;
-};
-
-TypingEvent::TypingEvent()
-    : Event(EventType::Typing)
-    , d( new Private )
-{
-}
-
-TypingEvent::~TypingEvent()
-{
-    delete d;
-}
-
-QStringList TypingEvent::users()
-{
-    return d->users;
-}
-
-TypingEvent* TypingEvent::fromJson(const QJsonObject& obj)
-{
-    TypingEvent* e = new TypingEvent();
-    e->parseJson(obj);
-    QJsonArray array = obj.value("content").toObject().value("user_ids").toArray();
+    QJsonValue result;
+    result= contentJson()["user_ids"];
+    QJsonArray array = result.toArray();
     for( const QJsonValue& user: array )
-    {
-        e->d->users << user.toString();
-    }
-    qCDebug(EPHEMERAL) << "Typing:" << e->d->users;
-    return e;
+        _users.push_back(user.toString());
 }
+

--- a/events/typingevent.h
+++ b/events/typingevent.h
@@ -27,15 +27,11 @@ namespace QMatrixClient
     class TypingEvent: public Event
     {
         public:
-            TypingEvent();
-            virtual ~TypingEvent();
+            TypingEvent(const QJsonObject& obj);
 
-            QStringList users();
-
-            static TypingEvent* fromJson(const QJsonObject& obj);
+            QStringList users() const { return _users; }
 
         private:
-            class Private;
-            Private* d;
+            QStringList _users;
     };
-}
+}  // namespace QMatrixClient

--- a/examples/qmc-example.cpp
+++ b/examples/qmc-example.cpp
@@ -1,12 +1,15 @@
-#include <iostream>
-#include <QCoreApplication>
 
 #include "connection.h"
 #include "room.h"
 
+#include <QCoreApplication>
+#include <iostream>
+#include <string>
+
 using namespace QMatrixClient;
 using std::cout;
 using std::endl;
+using std::string;
 
 void onNewRoom(Room* r)
 {
@@ -16,11 +19,11 @@ void onNewRoom(Room* r)
         cout << "  Name: " << r->name().toStdString() << endl;
         cout << "  Canonical alias: " << r->canonicalAlias().toStdString() << endl;
     });
-    QObject::connect(r, &Room::aboutToAddNewMessages, [=] (Events evs) {
+    QObject::connect(r, &Room::aboutToAddNewMessages, [=] (RoomEvents evs) {
         cout << "New events in room " << r->id().toStdString() << ":" << endl;
         for (auto e: evs)
         {
-            cout << e->originalJson().toStdString() << endl;
+            cout << string(e->originalJson()) << endl;
         }
     });
 }

--- a/jobs/passwordlogin.h
+++ b/jobs/passwordlogin.h
@@ -40,4 +40,4 @@ namespace QMatrixClient
             class Private;
             Private* d;
     };
-}
+}  // namespace QMatrixClient

--- a/jobs/roommessagesjob.cpp
+++ b/jobs/roommessagesjob.cpp
@@ -17,16 +17,15 @@
  */
 
 #include "roommessagesjob.h"
-#include "../util.h"
 
-#include <QtCore/QJsonArray>
+#include "util.h"
 
 using namespace QMatrixClient;
 
 class RoomMessagesJob::Private
 {
     public:
-        Owning<Events> events;
+        Owning<RoomEvents> events;
         QString end;
 };
 
@@ -49,7 +48,7 @@ RoomMessagesJob::~RoomMessagesJob()
     delete d;
 }
 
-Events RoomMessagesJob::releaseEvents()
+RoomEvents RoomMessagesJob::releaseEvents()
 {
     return d->events.release();
 }
@@ -62,7 +61,7 @@ QString RoomMessagesJob::end()
 BaseJob::Status RoomMessagesJob::parseJson(const QJsonDocument& data)
 {
     QJsonObject obj = data.object();
-    d->events.assign(eventsFromJson(obj.value("chunk").toArray()));
+    d->events.assign(makeEvents<RoomEvent>(obj.value("chunk").toArray()));
     d->end = obj.value("end").toString();
     return Success;
 }

--- a/jobs/roommessagesjob.h
+++ b/jobs/roommessagesjob.h
@@ -34,7 +34,7 @@ namespace QMatrixClient
                             FetchDirection dir = FetchDirection::Backward);
             virtual ~RoomMessagesJob();
 
-            Events releaseEvents();
+            RoomEvents releaseEvents();
             QString end();
 
         protected:

--- a/jobs/syncjob.cpp
+++ b/jobs/syncjob.cpp
@@ -18,7 +18,6 @@
 
 #include "syncjob.h"
 
-#include <QtCore/QJsonArray>
 #include <QtCore/QElapsedTimer>
 
 using namespace QMatrixClient;
@@ -94,11 +93,6 @@ BaseJob::Status SyncJob::parseJson(const QJsonDocument& data)
     qCDebug(PROFILER) << "*** SyncJob::parseJson():" << et.elapsed() << "ms";
 
     return Success;
-}
-
-void SyncRoomData::EventList::fromJson(const QJsonObject& roomContents)
-{
-    assign(eventsFromJson(roomContents[jsonKey].toObject()["events"].toArray()));
 }
 
 SyncRoomData::SyncRoomData(const QString& roomId_, JoinState joinState_,

--- a/room.h
+++ b/room.h
@@ -43,14 +43,14 @@ namespace QMatrixClient
             // a std:: container now
             using index_t = int;
 
-            TimelineItem(Event* e, index_t number) : evt(e), idx(number) { }
+            TimelineItem(RoomEvent* e, index_t number) : evt(e), idx(number) { }
 
-            Event* event() const { return evt.get(); }
-            Event* operator->() const { return event(); } //< Synonym for event()
+            RoomEvent* event() const { return evt.get(); }
+            RoomEvent* operator->() const { return event(); } //< Synonym for event()
             index_t index() const { return idx; }
 
         private:
-            std::unique_ptr<Event> evt;
+            std::unique_ptr<RoomEvent> evt;
             index_t idx;
     };
     inline QDebug& operator<<(QDebug& d, const TimelineItem& ti)
@@ -152,8 +152,8 @@ namespace QMatrixClient
             void userRenamed(User* user, QString oldName);
 
         signals:
-            void aboutToAddHistoricalMessages(const Events& events);
-            void aboutToAddNewMessages(const Events& events);
+            void aboutToAddHistoricalMessages(const RoomEvents& events);
+            void aboutToAddNewMessages(const RoomEvents& events);
             void addedMessages();
 
             /**
@@ -177,17 +177,17 @@ namespace QMatrixClient
             void unreadMessagesChanged(Room* room);
 
         protected:
-            virtual void doAddNewMessageEvents(const Events& events);
-            virtual void doAddHistoricalMessageEvents(const Events& events);
-            virtual void processStateEvents(const Events& events);
+            virtual void doAddNewMessageEvents(const RoomEvents& events);
+            virtual void doAddHistoricalMessageEvents(const RoomEvents& events);
+            virtual void processStateEvents(const RoomEvents& events);
             virtual void processEphemeralEvent(Event* event);
 
         private:
             class Private;
             Private* d;
 
-            void addNewMessageEvents(Events events);
-            void addHistoricalMessageEvents(Events events);
+            void addNewMessageEvents(RoomEvents events);
+            void addHistoricalMessageEvents(RoomEvents events);
 
             void markMessagesAsRead(rev_iter_t upToMarker);
     };
@@ -209,4 +209,4 @@ namespace QMatrixClient
         private:
             const Room* room;
     };
-}
+}  // namespace QMatrixClient

--- a/user.cpp
+++ b/user.cpp
@@ -133,7 +133,7 @@ void User::processEvent(Event* event)
 {
     if( event->type() == EventType::RoomMember )
     {
-        RoomMemberEvent* e = static_cast<RoomMemberEvent*>(event);
+        auto e = static_cast<RoomMemberEvent*>(event);
         if (e->membership() == MembershipType::Leave)
             return;
 

--- a/util.h
+++ b/util.h
@@ -18,6 +18,11 @@
 
 #pragma once
 
+#include <QtCore/QMetaEnum>
+#include <QtCore/QDebug>
+
+#include <functional>
+
 namespace QMatrixClient
 {
     /**
@@ -71,14 +76,19 @@ namespace QMatrixClient
      * @brief Lookup a value by a key in a varargs list
      *
      * This function template takes the value of its first argument (selector)
-     * as a key and searches for it in the key-value map passed in a varargs list
-     * (every next pair of arguments forms a key-value pair). If a match is found,
-     * the respective value is returned; if no pairs matched, the last value
-     * (fallback) is returned.
+     * as a key and searches for it in the key-value map passed in
+     * a parameter pack (every next pair of arguments forms a key-value pair).
+     * If a match is found, the respective value is returned; if no pairs
+     * matched, the last value (fallback) is returned.
      *
      * All options should be of the same type or implicitly castable to the
-     * type of the first option. Note that pointers to methods of different
-     * classes are of different object types, in particular.
+     * type of the first option. If you need some specific type to cast to
+     * you can explicitly provide it as the ValueT template parameter
+     * (e.g. <code>lookup<void*>(parameters...)</code>). Note that pointers
+     * to methods of different classes and even to functions with different
+     * signatures are of different types. If their return types are castable
+     * to some common one, @see dispatch that deals with this by swallowing
+     * the method invocation.
      *
      * Below is an example of usage to select a parser depending on contents of
      * a JSON object:
@@ -91,7 +101,7 @@ namespace QMatrixClient
      * }
      *
      * The implementation is based on tail recursion; every recursion step
-     * removes 2 arguments (match and option). There's no selector value for the
+     * removes 2 arguments (match and value). There's no selector value for the
      * fallback option (the last one); therefore, the total number of lookup()
      * arguments should be even: selector + n key-value pairs + fallback
      *
@@ -99,20 +109,128 @@ namespace QMatrixClient
      * (the first parameter) - most likely it won't do what you expect because
      * of shallow comparison.
      */
+    template <typename ValueT, typename SelectorT>
+    ValueT lookup(SelectorT/*unused*/, ValueT&& fallback)
+    {
+        return std::forward<ValueT>(fallback);
+    }
+
     template <typename ValueT, typename SelectorT, typename KeyT, typename... Ts>
-    ValueT lookup(SelectorT selector, KeyT key, ValueT value, Ts... remainingMapping)
+    ValueT lookup(SelectorT&& selector, KeyT&& key, ValueT&& value, Ts&&... remainder)
     {
         if( selector == key )
-            return value;
+            return std::forward<ValueT>(value);
 
         // Drop the failed key-value pair and recurse with 2 arguments less.
-        return lookup(selector, remainingMapping...);
+        return lookup<ValueT>(std::forward<SelectorT>(selector),
+                              std::forward<Ts>(remainder)...);
     }
 
-    template <typename SelectorT, typename ValueT>
-    ValueT lookup(SelectorT/*unused*/, ValueT fallback)
+    /**
+     * A wrapper around lookup() for functions of different types castable
+     * to a common std::function<> form
+     *
+     * This class uses std::function<> magic to first capture arguments of
+     * a yet-unknown function or function object, and then to coerce types of
+     * all functions/function objects passed for lookup to the type
+     * std::function<ResultT(ArgTs...). Without Dispatch<>, you would have
+     * to pass the specific function type to lookup, since your functions have
+     * different signatures. The type is not always obvious, and the resulting
+     * construct in client code would almost always be rather cumbersome.
+     * Dispatch<> deduces the necessary function type (well, almost - you still
+     * have to specify the result type) and hides the clumsiness. For more
+     * information on what std::function<> can wrap around, see
+     * https://cpptruths.blogspot.jp/2015/11/covariance-and-contravariance-in-c.html
+     *
+     * The function arguments are captured by value (i.e. copied) to avoid
+     * hard-to-find issues with dangling references in cases when a Dispatch<>
+     * object is passed across different contexts (e.g. returned from another
+     * function).
+     *
+     * \tparam ResultT - the desired type of a picked function invocation (mandatory)
+     * \tparam ArgTs - function argument types (deduced)
+     */
+    template <typename ResultT, typename... ArgTs>
+    class Dispatch
     {
-        return fallback;
+            // We take a chapter from functional programming here: Dispatch<>
+            // uses a function that in turn accepts a function as its argument.
+            // The sole purpose of the outer function (initialized by
+            // a lambda-expression in the constructor) is to store the arguments
+            // to any of the functions later looked up. The inner function (its
+            // type is defined by fn_t alias) is the one returned by lookup()
+            // invocation inside to().
+            //
+            // It's a bit counterintuitive to specify function parameters before
+            // the list of functions but otherwise it would take several overloads
+            // here to match all the ways a function-like behaviour can be done:
+            // reference-to-function, pointer-to-function, function object. For
+            // each of these overloads, we'd have to carefully retrieve the list
+            // of parameters and cover up possible reference-vs-value
+            // incompatibilities. Instead, you show what you have and if it's
+            // possible to bring all your functions to the same std::function<>
+            // based on what you have as parameters, the code will compile. If
+            // it's not possible, modern compilers are already good enough at
+            // pinpointing a specific place where types don't match.
+            using fn_t = std::function<ResultT(ArgTs...)>;
+        public:
+            explicit Dispatch(ArgTs&&... args)
+                : boundArgs([=](fn_t &&f) {
+                        return f(std::forward<ArgTs...>(args)...);
+                    })
+            { }
+
+            template <typename... LookupParamTs>
+            ResultT to(LookupParamTs&&... lookupParams)
+            {
+                // Here's the magic, two pieces of it:
+                // 1. Specifying fn_t in lookup() wraps all functions in
+                // \p lookupParams into the same std::function<> type. This
+                // includes conversion of return types from more specific to more
+                // generic (because std::function is covariant by return types and
+                // contravariant by argument types (see the link in the Doxygen
+                // part of the comments).
+                // 2. Passing the result of lookup() to boundArgs() invokes the
+                // lambda-expression mentioned in the constructor, which simply
+                // invokes this passed function with a set of arguments captured
+                // by lambda.
+                return boundArgs(
+                    lookup<fn_t>(std::forward<LookupParamTs>(lookupParams)...));
+            }
+
+        private:
+            std::function<ResultT(fn_t&&)> boundArgs;
+    };
+
+    /**
+     * Dispatch a set of parameters to one of a set of functions, depending on
+     * a selector value
+     *
+     * Use <code>dispatch<CommonType>(parameters).to(lookup parameters)</code>
+     * instead of lookup() if you need to pick one of several functions returning
+     * types castable to the same CommonType. See event.cpp for a typical use case.
+     *
+     * \see Dispatch
+     */
+    template <typename ResultT, typename... ArgTs>
+    Dispatch<ResultT, ArgTs...> dispatch(ArgTs&& ... args)
+    {
+        return Dispatch<ResultT, ArgTs...>(std::forward<ArgTs...>(args)...);
+    };
+
+    // The below enables pretty-printing of enums in logs
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 5, 0))
+#define REGISTER_ENUM(EnumName) Q_ENUM(EnumName)
+#else
+    // Thanks to Olivier for spelling it and for making Q_ENUM to replace it:
+    // https://woboq.com/blog/q_enum.html
+#define REGISTER_ENUM(EnumName) \
+    Q_ENUMS(EnumName) \
+    friend QDebug operator<<(QDebug dbg, EnumName val) \
+    { \
+        static int enumIdx = staticMetaObject.indexOfEnumerator(#EnumName); \
+        return dbg << Event::staticMetaObject.enumerator(enumIdx).valueToKey(int(val)); \
     }
+#endif
 }  // namespace QMatrixClient
 


### PR DESCRIPTION
The main purpose of this PR was to get rid of the pimpl idiom in the hierarchy of event classes. Pimpl implies that you have two `new` calls instead of one, and heap allocations are well-known to be expensive in terms of CPU time. Indeed, once I rewrote this part, I've got a more than two-fold reduction in event-creation-and-processing code - presumably also because of one-less pointer dereferencing on each event field access.

The other thing made along the way was getting the hierarchy a bit closer to the CS API spec. So I created one more "semi-base" class, `RoomEvent`, to keep values only relevant to room events, according to the spec. This allowed (actually, mandated) to drop `UnknownEvent`, since otherwise I would have to make separate classes for an unknown room event and an unknown generic event; at the same time, the stuff stored could taken almost equally easily from the base class (`content` was equal to `originalJson`, and `type` could be trivially retrieved from the original JSON if it _ever_ were needed - there were no references to its usage in the code, to begin with).

Rearranging things that way required to make `Event::fromJson()`, the factory, more flexible. So I rewrote the code in a more RAII style (using constructors instead of static methods to initialise fields) and accidentally got rid of `Event::parseJson()` because 80% of its code belonged to that `RoomEvent` constructor (it's just that there was no such class before).

One non-trivial thing to solve along the way was having `lookup()` invocations in two places now (in `Event::fromJson()` and `RoomEvent::fromJson()`), with a need them to return different object types. I stamp make some boilerplate code like `make<RoomEvent, RoomMessageEvent>` or similar but instead I thought I'd try to apply my skills in static polymorphism and keep it unified. That brought around the `Dispatch<>` template class which, while being very concise, engages some high-profile C++11 features, namely `std::function` (nested!) and parameter packs. Unfortunately, GCC 4.8, the oldest version that we still support, couldn't properly cope with parameter packs inside lambda-expressions so GCC 4.8 has been left with a basic implementation without parameter packs, barely sufficient for libqmatrixclient's needs. Fortunately, this code is very compact and unlikely to spill over to other places: basically, you just do `dispatch<>().to()` instead of `lookup()` and that's all you have to do about the templates and the stuff.