### PR TITLE
Expose userlist to QML

### DIFF
--- a/libqmatrixclient.pri
+++ b/libqmatrixclient.pri
@@ -8,7 +8,6 @@ HEADERS += \
     $$PWD/connection.h \
     $$PWD/room.h \
     $$PWD/user.h \
-    $$PWD/logmessage.h \
     $$PWD/state.h \
     $$PWD/events/event.h \
     $$PWD/events/roommessageevent.h \
@@ -19,7 +18,6 @@ HEADERS += \
     $$PWD/events/roomtopicevent.h \
     $$PWD/events/typingevent.h \
     $$PWD/events/receiptevent.h \
-    $$PWD/events/unknownevent.h \
     $$PWD/jobs/basejob.h \
     $$PWD/jobs/checkauthmethods.h \
     $$PWD/jobs/passwordlogin.h \
@@ -27,19 +25,18 @@ HEADERS += \
     $$PWD/jobs/postreceiptjob.h \
     $$PWD/jobs/joinroomjob.h \
     $$PWD/jobs/leaveroomjob.h \
-    $$PWD/jobs/roommembersjob.h \
     $$PWD/jobs/roommessagesjob.h \
     $$PWD/jobs/syncjob.h \
     $$PWD/jobs/mediathumbnailjob.h \
-    $$PWD/jobs/logoutjob.h
+    $$PWD/jobs/logoutjob.h \
+    $$PWD/logging.h \
+    $$PWD/settings.h
 
 SOURCES += \
     $$PWD/connectiondata.cpp \
     $$PWD/connection.cpp \
     $$PWD/room.cpp \
     $$PWD/user.cpp \
-    $$PWD/logmessage.cpp \
-    $$PWD/state.cpp \
     $$PWD/events/event.cpp \
     $$PWD/events/roommessageevent.cpp \
     $$PWD/events/roomnameevent.cpp \
@@ -49,7 +46,6 @@ SOURCES += \
     $$PWD/events/roomtopicevent.cpp \
     $$PWD/events/typingevent.cpp \
     $$PWD/events/receiptevent.cpp \
-    $$PWD/events/unknownevent.cpp \
     $$PWD/jobs/basejob.cpp \
     $$PWD/jobs/checkauthmethods.cpp \
     $$PWD/jobs/passwordlogin.cpp \
@@ -57,8 +53,9 @@ SOURCES += \
     $$PWD/jobs/postreceiptjob.cpp \
     $$PWD/jobs/joinroomjob.cpp \
     $$PWD/jobs/leaveroomjob.cpp \
-    $$PWD/jobs/roommembersjob.cpp \
     $$PWD/jobs/roommessagesjob.cpp \
     $$PWD/jobs/syncjob.cpp \
     $$PWD/jobs/mediathumbnailjob.cpp \
-    $$PWD/jobs/logoutjob.cpp
+    $$PWD/jobs/logoutjob.cpp \
+    $$PWD/logging.cpp \
+    $$PWD/settings.cpp

--- a/room.cpp
+++ b/room.cpp
@@ -370,6 +370,16 @@ QList< User* > Room::users() const
     return d->membersMap.values();
 }
 
+QStringList Room::memberNames() const {
+	QStringList res;
+
+	for (auto u : d->membersMap.values()) {
+        res.append( this->roomMembername(u) );
+    }
+
+	return res;
+}
+
 void Room::Private::insertMemberIntoMap(User *u)
 {
     auto namesakes = membersMap.values(u->name());

--- a/room.cpp
+++ b/room.cpp
@@ -24,8 +24,6 @@
 #include <QtCore/QJsonArray>
 #include <QtCore/QStringBuilder> // for efficient string concats (operator%)
 #include <QtCore/QElapsedTimer>
-#include <algorithm>
-#include <array>
 
 #include "connection.h"
 #include "state.h"

--- a/room.cpp
+++ b/room.cpp
@@ -24,6 +24,8 @@
 #include <QtCore/QJsonArray>
 #include <QtCore/QStringBuilder> // for efficient string concats (operator%)
 #include <QtCore/QElapsedTimer>
+#include <algorithm>
+#include <array>
 
 #include "connection.h"
 #include "state.h"

--- a/room.h
+++ b/room.h
@@ -90,6 +90,7 @@ namespace QMatrixClient
             QList<User*> membersLeft() const;
 
             Q_INVOKABLE QList<User*> users() const;
+            Q_INVOKABLE QStringList memberNames() const;
 
             /**
              * @brief Produces a disambiguated name for a given user in

--- a/settings.h
+++ b/settings.h
@@ -20,9 +20,9 @@
 
 #include <QtCore/QSettings>
 #include <QtCore/QVector>
+#include <QtCore/QUrl>
 
 class QVariant;
-class QUrl;
 
 namespace QMatrixClient
 {


### PR DESCRIPTION
Hi, this is the first pull request with changes I made to support development of the Tensor client.

Tensor is using QML for most of its user interface so some methods need to be exposed with Q_INVOKABLE. Furthermore, I use Qt Creator for development so I also updated the build file.

Let me know if this is ok