### PR TITLE
Split bridge name into a separate field in user model

### DIFF
--- a/room.cpp
+++ b/room.cpp
@@ -371,13 +371,13 @@ QList< User* > Room::users() const
 }
 
 QStringList Room::memberNames() const {
-	QStringList res;
+    QStringList res;
 
-	for (auto u : d->membersMap.values()) {
+    for (auto u : d->membersMap.values()) {
         res.append( this->roomMembername(u) );
     }
 
-	return res;
+    return res;
 }
 
 void Room::Private::insertMemberIntoMap(User *u)

--- a/user.cpp
+++ b/user.cpp
@@ -27,6 +27,7 @@
 #include <QtCore/QTimer>
 #include <QtCore/QDebug>
 #include <QtGui/QIcon>
+#include <QtCore/QRegularExpression>
 #include <algorithm>
 
 using namespace QMatrixClient;
@@ -52,6 +53,7 @@ class User::Private
         bool avatarValid;
         bool avatarOngoingRequest;
         QVector<QPixmap> scaledAvatars;
+        QString bridged;
 
         void requestAvatar();
 };
@@ -82,6 +84,10 @@ QString User::displayname() const
     if( !d->name.isEmpty() )
         return d->name;
     return d->userId;
+}
+
+QString User::bridged() const {
+    return d->bridged;
 }
 
 QPixmap User::avatar(int width, int height)
@@ -141,6 +147,12 @@ void User::processEvent(Event* event)
         {
             const auto oldName = d->name;
             d->name = e->displayName();
+            QRegularExpression reSuffix(" \\((IRC|Gitter)\\)$");
+            auto match = reSuffix.match(d->name);
+            if (match.hasMatch()) {
+                d->bridged = match.captured(1);
+                d->name = d->name.left(match.capturedStart(0));
+            }
             emit nameChanged(this, oldName);
         }
         if( d->avatarUrl != e->avatarUrl() )

--- a/user.h
+++ b/user.h
@@ -47,10 +47,10 @@ namespace QMatrixClient
              */
             Q_INVOKABLE QString displayname() const;
 
-			/**
-			  * Returns the name of bridge the user is connected from or empty.
-			  */
-			Q_INVOKABLE QString bridged() const;
+            /**
+             * Returns the name of bridge the user is connected from or empty.
+            */
+            Q_INVOKABLE QString bridged() const;
 
             QPixmap avatar(int requestedWidth, int requestedHeight);
             QPixmap croppedAvatar(int requestedWidth, int requestedHeight);

--- a/user.h
+++ b/user.h
@@ -47,6 +47,11 @@ namespace QMatrixClient
              */
             Q_INVOKABLE QString displayname() const;
 
+			/**
+			  * Returns the name of bridge the user is connected from or empty.
+			  */
+			Q_INVOKABLE QString bridged() const;
+
             QPixmap avatar(int requestedWidth, int requestedHeight);
             QPixmap croppedAvatar(int requestedWidth, int requestedHeight);
 


### PR DESCRIPTION
`name()` will no longer contain `(IRC)` and such