### PR TITLE
Persisting state using JSON

### DIFF
--- a/connection.cpp
+++ b/connection.cpp
@@ -61,7 +61,6 @@ class Connection::Private
         QString userId;
 
         SyncJob* syncJob;
-        QUrl stateSaveFile;
 };
 
 Connection::Connection(const QUrl& server, QObject* parent)
@@ -331,17 +330,7 @@ QByteArray Connection::generateTxnId()
     return d->data->generateTxnId();
 }
 
-QUrl Connection::getStateSaveFile() const {
-    return d->stateSaveFile;
-}
-
-void Connection::setStateSaveFile(const QUrl &path) {
-    d->stateSaveFile = path;
-}
-
-void Connection::saveState() {
-    if (getStateSaveFile().isEmpty()) return;
-
+void Connection::saveState(const QUrl &toFile) {
     QJsonObject rooms;
 
     for (auto i : this->roomMap()) {
@@ -363,7 +352,7 @@ void Connection::saveState() {
     QJsonDocument doc { rootObj };
     QByteArray data = doc.toJson();
 
-    QFileInfo stateFile { getStateSaveFile().toLocalFile() };
+    QFileInfo stateFile { toFile.toLocalFile() };
     QFile outfile { stateFile.absoluteFilePath() };
     if (!stateFile.dir().exists()) stateFile.dir().mkpath(".");
 
@@ -376,8 +365,8 @@ void Connection::saveState() {
     }
 }
 
-void Connection::loadState() {
-    QFile file { getStateSaveFile().toLocalFile() };
+void Connection::loadState(const QUrl &fromFile) {
+    QFile file { fromFile.toLocalFile() };
     if (!file.exists()) return;
     file.open(QFile::ReadOnly);
     QByteArray data = file.readAll();

--- a/connection.cpp
+++ b/connection.cpp
@@ -32,10 +32,9 @@
 #include "jobs/mediathumbnailjob.h"
 
 #include <QtNetwork/QDnsLookup>
-#include <QStandardPaths>
-#include <QFile>
-#include <QDir>
-#include <QFileInfo>
+#include <QtCore/QFile>
+#include <QtCore/QDir>
+#include <QtCore/QFileInfo>
 
 using namespace QMatrixClient;
 

--- a/connection.cpp
+++ b/connection.cpp
@@ -351,14 +351,14 @@ void Connection::saveState() {
     }
 
     QJsonObject roomObj;
-    roomObj["leave"] = QJsonObject();
-    roomObj["join"] = rooms;
-    roomObj["invite"] = QJsonObject();
+    roomObj.insert("leave", QJsonObject());
+    roomObj.insert("join", rooms);
+    roomObj.insert("invite", QJsonObject());
 
     QJsonObject rootObj;
-    rootObj["next_batch"] = d->data->lastEvent();
-    rootObj["presence"] = QJsonObject();
-    rootObj["rooms"] = roomObj;
+    rootObj.insert("next_batch", d->data->lastEvent());
+    rootObj.insert("presence", QJsonObject());
+    rootObj.insert("rooms", roomObj);
 
     QJsonDocument doc { rootObj };
     QByteArray data = doc.toJson();

--- a/connection.cpp
+++ b/connection.cpp
@@ -160,7 +160,7 @@ void Connection::sync(int timeout)
     auto job = d->syncJob =
             callApi<SyncJob>(d->data->lastEvent(), filter, timeout);
     connect( job, &SyncJob::success, [=] () {
-        onSyncSuccess(*job->data());
+        onSyncSuccess(job->data());
         d->syncJob = nullptr;
         emit syncDone();
     });

--- a/connection.cpp
+++ b/connection.cpp
@@ -333,8 +333,7 @@ void Connection::saveState(const QUrl &toFile) {
     QJsonObject rooms;
 
     for (auto i : this->roomMap()) {
-        QJsonObject roomObj;
-        i->toJson(roomObj);
+        QJsonObject roomObj = i->toJson();
         rooms[i->id()] = roomObj;
     }
 

--- a/connection.h
+++ b/connection.h
@@ -39,7 +39,7 @@ namespace QMatrixClient
 
     class Connection: public QObject {
             Q_OBJECT
-            Q_PROPERTY(QString stateSaveFile READ getStateSaveFile WRITE setStateSaveFile)
+            Q_PROPERTY(QUrl stateSaveFile READ getStateSaveFile WRITE setStateSaveFile)
         public:
             explicit Connection(const QUrl& server, QObject* parent = nullptr);
             Connection();
@@ -148,8 +148,8 @@ namespace QMatrixClient
             /**
              * Returns the path to file for saving state (rooms, presence, ...)
              */
-            QString getStateSaveFile() const;
-            void setStateSaveFile(const QString &path);
+            QUrl getStateSaveFile() const;
+            void setStateSaveFile(const QUrl &path);
 
             /**
              * Completes loading sync data.

--- a/connection.h
+++ b/connection.h
@@ -31,6 +31,7 @@ namespace QMatrixClient
     class ConnectionData;
 
     class SyncJob;
+    class SyncData;
     class RoomMessagesJob;
     class PostReceiptJob;
     class MediaThumbnailJob;
@@ -143,6 +144,15 @@ namespace QMatrixClient
              */
             virtual Room* createRoom(const QString& roomId);
 
+            /**
+             * Returns the path to file for saving state (rooms, presence, ...)
+             */
+            QString getStateSaveFile() const;
+
+            /**
+             * Completes loading sync data.
+             */
+            void onSyncSuccess(SyncData &data);
         private:
             class Private;
             Private* d;

--- a/connection.h
+++ b/connection.h
@@ -151,7 +151,7 @@ namespace QMatrixClient
             /**
              * Completes loading sync data.
              */
-            void onSyncSuccess(SyncData &data);
+            void onSyncSuccess(SyncData &&data);
 
         private:
             class Private;

--- a/connection.h
+++ b/connection.h
@@ -39,7 +39,6 @@ namespace QMatrixClient
 
     class Connection: public QObject {
             Q_OBJECT
-            Q_PROPERTY(QUrl stateSaveFile READ getStateSaveFile WRITE setStateSaveFile)
         public:
             explicit Connection(const QUrl& server, QObject* parent = nullptr);
             Connection();
@@ -85,9 +84,12 @@ namespace QMatrixClient
             Q_INVOKABLE SyncJob* syncJob() const;
             Q_INVOKABLE int millisToReconnect() const;
 
-            /** call this before first sync */
-            Q_INVOKABLE void loadState();
-            Q_INVOKABLE void saveState();
+            /**
+             * Call this before first sync to load from previously saved file.
+             * Uses QUrl to be QML-friendly.
+            */
+            Q_INVOKABLE void loadState(const QUrl &fromFile);
+            Q_INVOKABLE void saveState(const QUrl &toFile);
 
             template <typename JobT, typename... JobArgTs>
             JobT* callApi(JobArgTs... jobArgs) const
@@ -145,11 +147,6 @@ namespace QMatrixClient
              */
             virtual Room* createRoom(const QString& roomId);
 
-            /**
-             * Returns the path to file for saving state (rooms, presence, ...)
-             */
-            QUrl getStateSaveFile() const;
-            void setStateSaveFile(const QUrl &path);
 
             /**
              * Completes loading sync data.

--- a/connection.h
+++ b/connection.h
@@ -39,6 +39,7 @@ namespace QMatrixClient
 
     class Connection: public QObject {
             Q_OBJECT
+            Q_PROPERTY(QString stateSaveFile READ getStateSaveFile WRITE setStateSaveFile)
         public:
             explicit Connection(const QUrl& server, QObject* parent = nullptr);
             Connection();
@@ -148,11 +149,13 @@ namespace QMatrixClient
              * Returns the path to file for saving state (rooms, presence, ...)
              */
             QString getStateSaveFile() const;
+            void setStateSaveFile(const QString &path);
 
             /**
              * Completes loading sync data.
              */
             void onSyncSuccess(SyncData &data);
+
         private:
             class Private;
             Private* d;

--- a/connection.h
+++ b/connection.h
@@ -83,6 +83,10 @@ namespace QMatrixClient
             Q_INVOKABLE SyncJob* syncJob() const;
             Q_INVOKABLE int millisToReconnect() const;
 
+            /** call this before first sync */
+            Q_INVOKABLE void loadState();
+            Q_INVOKABLE void saveState();
+
             template <typename JobT, typename... JobArgTs>
             JobT* callApi(JobArgTs... jobArgs) const
             {

--- a/jobs/syncjob.cpp
+++ b/jobs/syncjob.cpp
@@ -66,7 +66,7 @@ BaseJob::Status SyncJob::parseJson(const QJsonDocument& data)
     return Success;
 }
 
-void SyncData::parseJson(const QJsonDocument &data) {
+BaseJob::Status SyncData::parseJson(const QJsonDocument &data) {
     QElapsedTimer et; et.start();
     QJsonObject json = data.object();
     nextBatch_ = json.value("next_batch").toString();
@@ -89,6 +89,7 @@ void SyncData::parseJson(const QJsonDocument &data) {
             roomData.emplace_back(rkey, roomState.enumVal, rs[rkey].toObject());
     }
     qCDebug(PROFILER) << "*** SyncData::parseJson():" << et.elapsed() << "ms";
+    return Success;
 }
 
 SyncRoomData::SyncRoomData(const QString& roomId_, JoinState joinState_,

--- a/jobs/syncjob.cpp
+++ b/jobs/syncjob.cpp
@@ -28,7 +28,6 @@ SyncJob::SyncJob(const ConnectionData* connection, const QString& since,
                  const QString& filter, int timeout, const QString& presence)
     : BaseJob(connection, HttpVerb::Get, QString("SyncJob-%1").arg(++jobId),
               "_matrix/client/r0/sync")
-    , d(new SyncData)
 {
     setLoggingCategory(SYNCJOB);
     QUrlQuery query;
@@ -45,11 +44,6 @@ SyncJob::SyncJob(const ConnectionData* connection, const QString& since,
     setMaxRetries(std::numeric_limits<int>::max());
 }
 
-SyncJob::~SyncJob()
-{
-    delete d;
-}
-
 QString SyncData::nextBatch() const
 {
     return nextBatch_;
@@ -62,7 +56,7 @@ SyncDataList&& SyncData::takeRoomData()
 
 BaseJob::Status SyncJob::parseJson(const QJsonDocument& data)
 {
-    return d->parseJson(data);
+    return d.parseJson(data);
 }
 
 BaseJob::Status SyncData::parseJson(const QJsonDocument &data) {

--- a/jobs/syncjob.cpp
+++ b/jobs/syncjob.cpp
@@ -62,8 +62,7 @@ SyncDataList&& SyncData::takeRoomData()
 
 BaseJob::Status SyncJob::parseJson(const QJsonDocument& data)
 {
-    d->parseJson(data);
-    return Success;
+    return d->parseJson(data);
 }
 
 BaseJob::Status SyncData::parseJson(const QJsonDocument &data) {
@@ -89,7 +88,7 @@ BaseJob::Status SyncData::parseJson(const QJsonDocument &data) {
             roomData.emplace_back(rkey, roomState.enumVal, rs[rkey].toObject());
     }
     qCDebug(PROFILER) << "*** SyncData::parseJson():" << et.elapsed() << "ms";
-    return Success;
+    return BaseJob::Success;
 }
 
 SyncRoomData::SyncRoomData(const QString& roomId_, JoinState joinState_,

--- a/jobs/syncjob.h
+++ b/jobs/syncjob.h
@@ -87,7 +87,7 @@ namespace QMatrixClient
                              const QString& filter = {},
                              int timeout = -1, const QString& presence = {});
 
-            SyncData &data() { return d; }
+            SyncData &&takeData() { return std::move(d); }
 
         protected:
             Status parseJson(const QJsonDocument& data) override;

--- a/jobs/syncjob.h
+++ b/jobs/syncjob.h
@@ -71,7 +71,7 @@ namespace QMatrixClient
 
     class SyncData {
     public:
-        void parseJson(const QJsonDocument &data);
+        BaseJob::Status parseJson(const QJsonDocument &data);
         SyncDataList&& takeRoomData();
         QString nextBatch() const;
 

--- a/jobs/syncjob.h
+++ b/jobs/syncjob.h
@@ -67,7 +67,18 @@ Q_DECLARE_TYPEINFO(QMatrixClient::SyncRoomData, Q_MOVABLE_TYPE);
 namespace QMatrixClient
 {
     // QVector cannot work with non-copiable objects, std::vector can.
-    using SyncData = std::vector<SyncRoomData>;
+    using SyncDataList = std::vector<SyncRoomData>;
+
+    class SyncData {
+    public:
+        void parseJson(const QJsonDocument &data);
+        SyncDataList&& takeRoomData();
+        QString nextBatch() const;
+
+    private:
+        QString nextBatch_;
+        SyncDataList roomData;
+    };
 
     class SyncJob: public BaseJob
     {
@@ -77,14 +88,12 @@ namespace QMatrixClient
                              int timeout = -1, const QString& presence = {});
             virtual ~SyncJob();
 
-            SyncData&& takeRoomData();
-            QString nextBatch() const;
+            SyncData *data() const { return d; }
 
         protected:
             Status parseJson(const QJsonDocument& data) override;
 
         private:
-            class Private;
-            Private* d;
+            SyncData* d;
     };
 }  // namespace QMatrixClient

--- a/jobs/syncjob.h
+++ b/jobs/syncjob.h
@@ -86,14 +86,13 @@ namespace QMatrixClient
             explicit SyncJob(const ConnectionData* connection, const QString& since = {},
                              const QString& filter = {},
                              int timeout = -1, const QString& presence = {});
-            virtual ~SyncJob();
 
-            SyncData *data() const { return d; }
+            SyncData &data() { return d; }
 
         protected:
             Status parseJson(const QJsonDocument& data) override;
 
         private:
-            SyncData* d;
+            SyncData d;
     };
 }  // namespace QMatrixClient

--- a/room.cpp
+++ b/room.cpp
@@ -119,7 +119,7 @@ class Room::Private
         void setLastReadEvent(User* u, const QString& eventId);
         rev_iter_pair_t promoteReadMarker(User* u, rev_iter_t newMarker);
 
-        void toJson(QJsonObject &out);
+        QJsonObject toJson() const;
 
     private:
         QString calculateDisplayname() const;
@@ -877,7 +877,7 @@ void Room::Private::updateDisplayname()
         emit q->displaynameChanged(q);
 }
 
-void Room::Private::toJson(QJsonObject &out) {
+QJsonObject Room::Private::toJson() const {
     QJsonValue nowTimestamp { QDateTime::currentMSecsSinceEpoch() };
     QJsonArray stateEvents;
 
@@ -890,7 +890,7 @@ void Room::Private::toJson(QJsonObject &out) {
     nameEvent.insert("content", nameEventContent);
     stateEvents.append(nameEvent);
 
-    for (auto i : this->membersMap) {
+    for (const auto &i : this->membersMap) {
         QJsonObject content;
         content.insert("membership", QStringLiteral("join"));
         content.insert("displayname", i->displayname());
@@ -908,7 +908,7 @@ void Room::Private::toJson(QJsonObject &out) {
 
     {
         QJsonArray aliases;
-        for (auto i : this->aliases) {
+        for (const auto &i : this->aliases) {
             aliases.append(QJsonValue(i));
         }
 
@@ -935,11 +935,14 @@ void Room::Private::toJson(QJsonObject &out) {
 
     QJsonObject roomStateObj;
     roomStateObj.insert("events", stateEvents);
-    out.insert("state", roomStateObj);
+
+    QJsonObject result;
+    result.insert("state", roomStateObj);
+    return result;
 }
 
-void Room::toJson(QJsonObject &out) const {
-    d->toJson(out);
+QJsonObject Room::toJson() const {
+    return d->toJson();
 }
 
 MemberSorter Room::memberSorter() const

--- a/room.cpp
+++ b/room.cpp
@@ -881,25 +881,26 @@ void Room::Private::toJson(QJsonObject &out) {
     QJsonValue nowTimestamp { QDateTime::currentMSecsSinceEpoch() };
     QJsonArray stateEvents;
 
-    QJsonObject nameEvent {
-        {"type", QJsonValue("m.room.name")},
-        {"content", QJsonValue({qMakePair(QString("name"), QJsonValue(this->name))})}};
+    QJsonObject nameEvent;
+    nameEvent["type"] = QString("m.room.name");
+    QJsonObject nameEventContent;
+    nameEventContent["name"] = this->name;
+    nameEvent["content"] = nameEventContent;
     stateEvents.append(QJsonValue(nameEvent));
 
     for (auto i : this->membersMap) {
-        QJsonObject content {
-            {"membership", QJsonValue("join")},
-            {"displayname", QJsonValue(i->displayname())}
-            // avatar URL is not available
-        };
-        QJsonObject memberEvent {
-            {"type", QJsonValue("m.room.member")},
-            {"sender", QJsonValue(i->id())},
-            {"state_key", QJsonValue(i->id())},
-            {"content", QJsonValue(content)},
-            {"membership", QJsonValue("join")},
-            {"origin_server_ts", nowTimestamp}
-        };
+        QJsonObject content;
+        content["membership"] = QString("join");
+        content["displayname"] = i->displayname();
+        // avatar URL is not available
+
+        QJsonObject memberEvent;
+        memberEvent["type"] = QString("m.room.member");
+        memberEvent["sender"] = (i->id());
+        memberEvent["state_key"] = (i->id());
+        memberEvent["content"] = (content);
+        memberEvent["membership"] = QString("join");
+        memberEvent["origin_server_ts"] = nowTimestamp;
         stateEvents.append(QJsonValue(memberEvent));
     }
 
@@ -909,31 +910,30 @@ void Room::Private::toJson(QJsonObject &out) {
             aliases.append(QJsonValue(i));
         }
 
-        QJsonObject content {
-            {"aliases", QJsonValue(aliases)}
-        };
+        QJsonObject content;
+        content["aliases"] = QJsonValue(aliases);
 
-        QJsonObject aliasEvent {
-            {"type", QJsonValue("m.room.aliases")},
-            {"origin_server_ts", nowTimestamp},
-            {"content", QJsonValue(content)}
-        };
+        QJsonObject aliasEvent;
+        aliasEvent["type"] = QString("m.room.aliases");
+        aliasEvent["origin_server_ts"] = nowTimestamp;
+        aliasEvent["content"] = (content);
 
         stateEvents.append(QJsonValue(aliasEvent));
     }
 
     {
-        QJsonObject content {
-            {"alias", QJsonValue(this->canonicalAlias)}
-        };
-        QJsonObject canonicalAliasEvent {
-            {"type", QJsonValue("m.room.canonical_alias")},
-            {"origin_server_ts", nowTimestamp}
-        };
+        QJsonObject content;
+        content["alias"] = (this->canonicalAlias);
+
+        QJsonObject canonicalAliasEvent;
+        canonicalAliasEvent["type"] = QString("m.room.canonical_alias");
+        canonicalAliasEvent["origin_server_ts"] = nowTimestamp;
         stateEvents.append(QJsonValue(canonicalAliasEvent));
     }
 
-    out["state"] = QJsonValue({qMakePair(QString("events"), QJsonValue(stateEvents))});
+    QJsonObject roomStateObj;
+    roomStateObj["events"] = QJsonValue(stateEvents);
+    out["state"] = roomStateObj;
 }
 
 void Room::toJson(QJsonObject &out) const {

--- a/room.cpp
+++ b/room.cpp
@@ -882,26 +882,28 @@ void Room::Private::toJson(QJsonObject &out) {
     QJsonArray stateEvents;
 
     QJsonObject nameEvent;
-    nameEvent["type"] = QString("m.room.name");
+    nameEvent.insert("type", QStringLiteral("m.room.name"));
+
     QJsonObject nameEventContent;
-    nameEventContent["name"] = this->name;
-    nameEvent["content"] = nameEventContent;
-    stateEvents.append(QJsonValue(nameEvent));
+    nameEventContent.insert("name", this->name);
+
+    nameEvent.insert("content", nameEventContent);
+    stateEvents.append(nameEvent);
 
     for (auto i : this->membersMap) {
         QJsonObject content;
-        content["membership"] = QString("join");
-        content["displayname"] = i->displayname();
+        content.insert("membership", QStringLiteral("join"));
+        content.insert("displayname", i->displayname());
         // avatar URL is not available
 
         QJsonObject memberEvent;
-        memberEvent["type"] = QString("m.room.member");
-        memberEvent["sender"] = (i->id());
-        memberEvent["state_key"] = (i->id());
-        memberEvent["content"] = (content);
-        memberEvent["membership"] = QString("join");
-        memberEvent["origin_server_ts"] = nowTimestamp;
-        stateEvents.append(QJsonValue(memberEvent));
+        memberEvent.insert("type", QStringLiteral("m.room.member"));
+        memberEvent.insert("sender", i->id());
+        memberEvent.insert("state_key", i->id());
+        memberEvent.insert("content", content);
+        memberEvent.insert("membership", QStringLiteral("join"));
+        memberEvent.insert("origin_server_ts", nowTimestamp);
+        stateEvents.append(memberEvent);
     }
 
     {
@@ -911,29 +913,29 @@ void Room::Private::toJson(QJsonObject &out) {
         }
 
         QJsonObject content;
-        content["aliases"] = QJsonValue(aliases);
+        content.insert("aliases", aliases);
 
         QJsonObject aliasEvent;
-        aliasEvent["type"] = QString("m.room.aliases");
-        aliasEvent["origin_server_ts"] = nowTimestamp;
-        aliasEvent["content"] = (content);
+        aliasEvent.insert("type", QStringLiteral("m.room.aliases"));
+        aliasEvent.insert("origin_server_ts", nowTimestamp);
+        aliasEvent.insert("content", content);
 
-        stateEvents.append(QJsonValue(aliasEvent));
+        stateEvents.append(aliasEvent);
     }
 
     {
         QJsonObject content;
-        content["alias"] = (this->canonicalAlias);
+        content.insert("alias", this->canonicalAlias);
 
         QJsonObject canonicalAliasEvent;
-        canonicalAliasEvent["type"] = QString("m.room.canonical_alias");
-        canonicalAliasEvent["origin_server_ts"] = nowTimestamp;
-        stateEvents.append(QJsonValue(canonicalAliasEvent));
+        canonicalAliasEvent.insert("type", QStringLiteral("m.room.canonical_alias"));
+        canonicalAliasEvent.insert("origin_server_ts", nowTimestamp);
+        stateEvents.append(canonicalAliasEvent);
     }
 
     QJsonObject roomStateObj;
-    roomStateObj["events"] = QJsonValue(stateEvents);
-    out["state"] = roomStateObj;
+    roomStateObj.insert("events", stateEvents);
+    out.insert("state", roomStateObj);
 }
 
 void Room::toJson(QJsonObject &out) const {

--- a/room.h
+++ b/room.h
@@ -142,6 +142,8 @@ namespace QMatrixClient
 
             MemberSorter memberSorter() const;
 
+            void toJson(QJsonObject &out) const;
+
         public slots:
             void postMessage(const QString& plainText,
                              MessageEventType type = MessageEventType::Text);

--- a/room.h
+++ b/room.h
@@ -142,7 +142,7 @@ namespace QMatrixClient
 
             MemberSorter memberSorter() const;
 
-            void toJson(QJsonObject &out) const;
+            QJsonObject toJson() const;
 
         public slots:
             void postMessage(const QString& plainText,


### PR DESCRIPTION
Basic implementation first. Saves information in the same JSON structure as the sync response from matrix. Some data such as event id's are not being kept though so they are ignored which means the library complains that they are missing. Currently don't have a plan to deal with that.

The idea for loading is to change `SyncJob::Private` class to a public `SyncData` class that is generated by loading the JSON. Then move common processing of this into a function.