### PR TITLE
Connection: Room and User factories are std::functions now

### DIFF
--- a/connection.cpp
+++ b/connection.cpp
@@ -238,7 +238,7 @@ User* Connection::user(const QString& userId)
 {
     if( d->userMap.contains(userId) )
         return d->userMap.value(userId);
-    User* user = createUser(userId);
+    auto* user = createUser(this, userId);
     d->userMap.insert(userId, user);
     return user;
 }
@@ -297,7 +297,7 @@ Room* Connection::provideRoom(const QString& id)
         return d->roomMap.value(id);
 
     // Not yet in the map, create a new one.
-    Room* room = createRoom(id);
+    auto* room = createRoom(this, id);
     if (room)
     {
         d->roomMap.insert( id, room );
@@ -309,15 +309,11 @@ Room* Connection::provideRoom(const QString& id)
     return room;
 }
 
-User* Connection::createUser(const QString& userId)
-{
-    return new User(userId, this);
-}
+std::function<Room*(Connection*, const QString&)> Connection::createRoom =
+    [](Connection* c, const QString& id) { return new Room(c, id); };
 
-Room* Connection::createRoom(const QString& roomId)
-{
-    return new Room(this, roomId);
-}
+std::function<User*(Connection*, const QString&)> Connection::createUser =
+    [](Connection* c, const QString& id) { return new User(id, c); };
 
 QByteArray Connection::generateTxnId()
 {

--- a/connection.h
+++ b/connection.h
@@ -22,6 +22,8 @@
 #include <QtCore/QUrl>
 #include <QtCore/QSize>
 
+#include <functional>
+
 namespace QMatrixClient
 {
     class Room;
@@ -96,6 +98,20 @@ namespace QMatrixClient
              */
             Q_INVOKABLE QByteArray generateTxnId();
 
+            template <typename T = Room>
+            static void setRoomType()
+            {
+                createRoom =
+                    [](Connection* c, const QString& id) { return new T(c, id); };
+            }
+
+            template <typename T = User>
+            static void setUserType()
+            {
+                createUser =
+                    [](Connection* c, const QString& id) { return new T(id, c); };
+            }
+
         signals:
             void resolved();
             void connected();
@@ -130,18 +146,11 @@ namespace QMatrixClient
              */
             Room* provideRoom(const QString& roomId);
 
-            /**
-             * makes it possible for derived classes to have its own User class
-             */
-            virtual User* createUser(const QString& userId);
-
-            /**
-             * makes it possible for derived classes to have its own Room class
-             */
-            virtual Room* createRoom(const QString& roomId);
-
         private:
             class Private;
             Private* d;
+
+            static std::function<Room*(Connection*, const QString&)> createRoom;
+            static std::function<User*(Connection*, const QString&)> createUser;
     };
 }  // namespace QMatrixClient


### PR DESCRIPTION
Instead of `createUser()` and `createRoom()` virtual functions, use `std::function<>` to store predefined lambdas that would create respective descendants from `User` and `Room`, respectively. No more need of `QuaternionConnection` just for the sake of creating a `QuaternionRoom` in Quaternion code. This PR also has convenience functions to set `createUser` and `createRoom` to predefined obvious implementations that call `operator new()`, parameterised by a particular type inheriting from `User` or `Room` respectively.