### PR TITLE
Support inviting, kicking and dealing with rooms in Invite state

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,11 +81,13 @@ set(libqmatrixclient_SRCS
    jobs/syncjob.cpp
    jobs/mediathumbnailjob.cpp
    jobs/logoutjob.cpp
-    )
+)
+
+aux_source_directory(jobs/generated libqmatrixclient_job_SRCS)
 
 set(example_SRCS examples/qmc-example.cpp)
 
-add_library(qmatrixclient ${libqmatrixclient_SRCS})
+add_library(qmatrixclient ${libqmatrixclient_SRCS} ${libqmatrixclient_job_SRCS})
 set_property(TARGET qmatrixclient PROPERTY VERSION "0.0.0")
 set_property(TARGET qmatrixclient PROPERTY SOVERSION 0 )
 

--- a/connection.h
+++ b/connection.h
@@ -52,7 +52,7 @@ namespace QMatrixClient
             Connection();
             virtual ~Connection();
 
-            const QHash<QPair<QString, bool>, Room*>& roomMap() const;
+            QHash<QPair<QString, bool>, Room*> roomMap() const;
 
             Q_INVOKABLE virtual void resolveServer(const QString& domain);
             Q_INVOKABLE virtual void connectToServer(const QString& user,
@@ -128,8 +128,9 @@ namespace QMatrixClient
 
             void syncDone();
             void newRoom(Room* room);
-            void joinedRoom(Room* room);
-            void leftRoom(Room* room);
+            void joinedRoom(Room* room, Room* prevInvite);
+            void leftRoom(Room* room, Room* prevInvite);
+            void aboutToDeleteRoom(Room* room);
 
             void loginError(QString error);
             void networkError(size_t nextAttempt, int inMilliseconds);

--- a/connection.h
+++ b/connection.h
@@ -128,8 +128,9 @@ namespace QMatrixClient
 
             void syncDone();
             void newRoom(Room* room);
-            void joinedRoom(Room* room, Room* prevInvite);
-            void leftRoom(Room* room, Room* prevInvite);
+            void invitedRoom(Room* room, Room* prev);
+            void joinedRoom(Room* room, Room* prev);
+            void leftRoom(Room* room, Room* prev);
             void aboutToDeleteRoom(Room* room);
 
             void loginError(QString error);

--- a/jobs/converters.h
+++ b/jobs/converters.h
@@ -21,6 +21,7 @@
 #include <QtCore/QJsonValue>
 #include <QtCore/QJsonArray>
 #include <QtCore/QDate>
+#include <QtCore/QVariant>
 
 namespace QMatrixClient
 {
@@ -83,7 +84,6 @@ namespace QMatrixClient
     template <>
     inline QDate fromJson<QDate>(const QJsonValue& jv)
     {
-        return QDateTime::fromMSecsSinceEpoch(
-            fromJson<qint64>(jv), Qt::UTC).date();
+        return fromJson<QDateTime>(jv).date();
     }
 }  // namespace QMatrixClient

--- a/jobs/converters.h
+++ b/jobs/converters.h
@@ -1,0 +1,89 @@
+/******************************************************************************
+* Copyright (C) 2017 Kitsune Ral <kitsune-ral@users.sf.net>
+*
+* This library is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this library; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#include <QtCore/QJsonValue>
+#include <QtCore/QJsonArray>
+#include <QtCore/QDate>
+
+namespace QMatrixClient
+{
+    template <typename T>
+    inline QJsonValue toJson(T val)
+    {
+        return QJsonValue(val);
+    }
+
+    template <typename T>
+    inline QJsonValue toJson(const QVector<T>& vals)
+    {
+        QJsonArray ar;
+        for (const auto& v: vals)
+            ar.push_back(toJson(v));
+        return ar;
+    }
+
+    inline QJsonValue toJson(const QStringList& strings)
+    {
+        return QJsonArray::fromStringList(strings);
+    }
+
+    template <typename T>
+    inline T fromJson(const QJsonValue& jv)
+    {
+        return QVariant(jv).value<T>();
+    }
+
+    template <>
+    inline int fromJson<int>(const QJsonValue& jv)
+    {
+        return jv.toInt();
+    }
+
+    template <>
+    inline qint64 fromJson<qint64>(const QJsonValue& jv)
+    {
+        return static_cast<qint64>(jv.toDouble());
+    }
+
+    template <>
+    inline double fromJson<double>(const QJsonValue& jv)
+    {
+        return jv.toDouble();
+    }
+
+    template <>
+    inline QString fromJson<QString>(const QJsonValue& jv)
+    {
+        return jv.toString();
+    }
+
+    template <>
+    inline QDateTime fromJson<QDateTime>(const QJsonValue& jv)
+    {
+        return QDateTime::fromMSecsSinceEpoch(fromJson<qint64>(jv), Qt::UTC);
+    }
+
+    template <>
+    inline QDate fromJson<QDate>(const QJsonValue& jv)
+    {
+        return QDateTime::fromMSecsSinceEpoch(
+            fromJson<qint64>(jv), Qt::UTC).date();
+    }
+}  // namespace QMatrixClient

--- a/jobs/generated/inviting.cpp
+++ b/jobs/generated/inviting.cpp
@@ -1,0 +1,37 @@
+/******************************************************************************
+ * THIS FILE IS GENERATED - ANY EDITS WILL BE OVERWRITTEN
+ */
+
+
+#include "inviting.h"
+
+
+#include "../converters.h"
+
+#include <QtCore/QStringBuilder>
+
+using namespace QMatrixClient;
+
+    
+
+static const auto basePath = QStringLiteral("/_matrix/client/r0");
+
+    
+InviteUserJob::InviteUserJob(const ConnectionData* connection, 
+            QString roomId
+        , 
+            QString user_id
+        )
+    : BaseJob(connection, HttpVerb::Post, "InviteUserJob"
+        , basePath % "/rooms/" % roomId % "/invite"
+        , Query {  }
+        , Data { 
+              { "user_id", toJson(user_id) }
+         }
+        
+    )
+{ }
+    
+
+    
+

--- a/jobs/generated/inviting.h
+++ b/jobs/generated/inviting.h
@@ -1,0 +1,42 @@
+/******************************************************************************
+ * THIS FILE IS GENERATED - ANY EDITS WILL BE OVERWRITTEN
+ */
+
+
+#pragma once
+
+
+#include "../basejob.h"
+
+
+
+#include <QtCore/QString>
+
+
+
+
+namespace QMatrixClient
+{
+
+
+    // Operations
+    
+    /**
+     
+     */
+    class InviteUserJob : public BaseJob
+    {
+        public:
+            InviteUserJob(const ConnectionData* connection
+            
+                    , 
+                    QString roomId
+            
+                    , 
+                    QString user_id
+            );
+    
+    };
+    
+
+} // namespace QMatrixClient

--- a/jobs/generated/kicking.cpp
+++ b/jobs/generated/kicking.cpp
@@ -1,0 +1,41 @@
+/******************************************************************************
+ * THIS FILE IS GENERATED - ANY EDITS WILL BE OVERWRITTEN
+ */
+
+
+#include "kicking.h"
+
+
+#include "../converters.h"
+
+#include <QtCore/QStringBuilder>
+
+using namespace QMatrixClient;
+
+    
+
+static const auto basePath = QStringLiteral("/_matrix/client/r0");
+
+    
+KickJob::KickJob(const ConnectionData* connection, 
+            QString roomId
+        , 
+            QString user_id
+        , 
+            QString reason
+        )
+    : BaseJob(connection, HttpVerb::Post, "KickJob"
+        , basePath % "/rooms/" % roomId % "/kick"
+        , Query {  }
+        , Data { 
+              { "user_id", toJson(user_id) }, 
+        
+              { "reason", toJson(reason) }
+         }
+        
+    )
+{ }
+    
+
+    
+

--- a/jobs/generated/kicking.h
+++ b/jobs/generated/kicking.h
@@ -1,0 +1,45 @@
+/******************************************************************************
+ * THIS FILE IS GENERATED - ANY EDITS WILL BE OVERWRITTEN
+ */
+
+
+#pragma once
+
+
+#include "../basejob.h"
+
+
+
+#include <QtCore/QString>
+
+
+
+
+namespace QMatrixClient
+{
+
+
+    // Operations
+    
+    /**
+     
+     */
+    class KickJob : public BaseJob
+    {
+        public:
+            KickJob(const ConnectionData* connection
+            
+                    , 
+                    QString roomId
+            
+                    , 
+                    QString user_id
+            
+                    , 
+                    QString reason
+            );
+    
+    };
+    
+
+} // namespace QMatrixClient

--- a/jobs/syncjob.cpp
+++ b/jobs/syncjob.cpp
@@ -99,15 +99,14 @@ SyncRoomData::SyncRoomData(const QString& roomId_, JoinState joinState_,
                            const QJsonObject& room_)
     : roomId(roomId_)
     , joinState(joinState_)
-    , state("state")
+    , state(joinState == JoinState::Invite ? "invite_state" : "state")
     , timeline("timeline")
     , ephemeral("ephemeral")
     , accountData("account_data")
-    , inviteState("invite_state")
 {
     switch (joinState) {
         case JoinState::Invite:
-            inviteState.fromJson(room_);
+            state.fromJson(room_);
             break;
         case JoinState::Join:
             state.fromJson(room_);

--- a/jobs/syncjob.h
+++ b/jobs/syncjob.h
@@ -51,7 +51,6 @@ namespace QMatrixClient
             Batch<RoomEvent> timeline;
             Batch<Event> ephemeral;
             Batch<Event> accountData;
-            Batch<Event> inviteState;
 
             bool timelineLimited;
             QString timelinePrevBatch;

--- a/room.cpp
+++ b/room.cpp
@@ -18,6 +18,9 @@
 
 #include "room.h"
 
+#include "jobs/generated/kicking.h"
+#include "jobs/generated/inviting.h"
+
 #include <array>
 
 #include <QtCore/QHash>
@@ -48,9 +51,9 @@ class Room::Private
         typedef QMultiHash<QString, User*> members_map_t;
         typedef std::pair<rev_iter_t, rev_iter_t> rev_iter_pair_t;
 
-        Private(Connection* c, QString id_)
+        Private(Connection* c, QString id_, JoinState initialJoinState)
             : q(nullptr), connection(c), id(std::move(id_))
-            , joinState(JoinState::Join), unreadMessages(false)
+            , joinState(initialJoinState), unreadMessages(false)
             , highlightCount(0), notificationCount(0), roomMessagesJob(nullptr)
         { }
 
@@ -134,8 +137,8 @@ class Room::Private
         }
 };
 
-Room::Room(Connection* connection, QString id)
-    : QObject(connection), d(new Private(connection, id))
+Room::Room(Connection* connection, QString id, JoinState initialJoinState)
+    : QObject(connection), d(new Private(connection, id, initialJoinState))
 {
     // See "Accessing the Public Class" section in
     // https://marcmutz.wordpress.com/translated-articles/pimp-my-pimpl-%E2%80%94-reloaded/
@@ -194,6 +197,8 @@ void Room::setJoinState(JoinState state)
     if( state == oldState )
         return;
     d->joinState = state;
+    qCDebug(MAIN) << "Room" << id() << "changed state: "
+                  << int(oldState) << "->" << int(state);
     emit joinStateChanged(oldState, state);
 }
 
@@ -601,9 +606,19 @@ void Room::Private::getPreviousContent(int limit)
     }
 }
 
+void Room::inviteToRoom(const QString& memberId) const
+{
+    connection()->callApi<InviteUserJob>(id(), memberId);
+}
+
 void Room::leaveRoom() const
 {
     connection()->callApi<LeaveRoomJob>(id());
+}
+
+void Room::kickMember(const QString& memberId, const QString& reason) const
+{
+    connection()->callApi<KickJob>(id(), memberId, reason);
 }
 
 void Room::Private::dropDuplicateEvents(RoomEvents* events) const

--- a/room.h
+++ b/room.h
@@ -77,7 +77,7 @@ namespace QMatrixClient
             using Timeline = std::deque<TimelineItem>;
             using rev_iter_t = Timeline::const_reverse_iterator;
 
-            Room(Connection* connection, QString id);
+            Room(Connection* connection, QString id, JoinState initialJoinState);
             virtual ~Room();
 
             Connection* connection() const;
@@ -154,7 +154,10 @@ namespace QMatrixClient
 
             void getPreviousContent(int limit = 10);
 
+            void inviteToRoom(const QString& memberId) const;
             void leaveRoom() const;
+            void kickMember(const QString& memberId, const QString& reason) const;
+
             void userRenamed(User* user, QString oldName);
 
             /** Mark all messages in the room as read */


### PR DESCRIPTION
This PR provides necessary plumbing in `Connection` so that it could process and advertise all things around inviting, as well as room state changes from Invite to Join or Leave (the spec is a bit quirky on that, see the comment on `invite_state` for [/sync](https://matrix.org/speculator/spec/HEAD/client_server/unstable.html#get-matrix-client-r0-sync)). This is also the first PR to introduce jobs that are automatically generated from the Matrix CS API spec (so far they are as simple as `InviteJob` and `KickJob`).

Partially addresses #38 
Closes #33 