### PR TITLE
add cmake install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,3 +98,9 @@ if (WIN32)
     install (FILES mime/packages/freedesktop.org.xml
              DESTINATION mime/packages)
 endif (WIN32)
+
+install (TARGETS qmatrixclient
+         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install (FILES avatar.h connection.h connectiondata.h converters.h
+         joinstate.h logging.h room.h settings.h state.h user.h util.h
+         DESTINATION ${INCLUDE_INSTALL_DIR})


### PR DESCRIPTION
After reading through https://github.com/QMatrixClient/Quaternion/issues/239, I decided to work on this again.

This change is not all that is needed to use it as a shared library though, includes have to be adjusted as well. Example log excerpt when building Quaternion against the shared library:
```
[    7s]  /usr/include/room.h:30:10: fatal error: jobs/syncjob.h: No such file or directory
[    7s]  #include "jobs/syncjob.h"
[    7s]           ^~~~~~~~~~~~~~~~
[    7s] compilation terminated.
```
I still wanted to open this PR at this time, the installation part does work fine.
Fixes #113.