### PR TITLE
Making it compile for android

### DIFF
--- a/events/tagevent.cpp
+++ b/events/tagevent.cpp
@@ -44,7 +44,7 @@ QStringList TagEvent::tagNames() const
 QHash<QString, TagRecord> TagEvent::tags() const
 {
     QHash<QString, TagRecord> result;
-    auto allTags { tagsObject() };
+    auto allTags = tagsObject();
     for (auto it = allTags.begin(); it != allTags.end(); ++ it)
         result.insert(it.key(), TagRecord(it.value().toObject()));
     return result;

--- a/jobs/syncjob.cpp
+++ b/jobs/syncjob.cpp
@@ -68,7 +68,7 @@ BaseJob::Status SyncData::parseJson(const QJsonDocument &data)
 {
     QElapsedTimer et; et.start();
 
-    auto json { data.object() };
+    auto json = data.object();
     nextBatch_ = json.value("next_batch").toString();
     // TODO: presence
     accountData.fromJson(json);


### PR DESCRIPTION
While NDK is abandoning GCC for Clang, QtCreator is not quite up to speed yet. For now, these minor changes seem to do the job.