### PR TITLE
fix error handling in loadState()

### DIFF
--- a/connection.cpp
+++ b/connection.cpp
@@ -719,15 +719,18 @@ void Connection::loadState(const QUrl &fromFile)
         qCDebug(MAIN) << "No state cache file found";
         return;
     }
-    file.open(QFile::ReadOnly);
+    if(!file.open(QFile::ReadOnly))
+    {
+        qCWarning(MAIN) << "file " << file.fileName() << "failed to open for read";
+        return;
+    }
     QByteArray data = file.readAll();
 
-    QJsonParseError e;
     auto jsonDoc = d->cacheToBinary ? QJsonDocument::fromBinaryData(data) :
-                                      QJsonDocument::fromJson(data, &e);
-    if (e.error != QJsonParseError::NoError)
+                                      QJsonDocument::fromJson(data);
+    if (jsonDoc.isNull())
     {
-        qCWarning(MAIN) << "Cache file not found or broken, discarding";
+        qCWarning(MAIN) << "Cache file broken, discarding";
         return;
     }
     auto actualCacheVersionMajor =


### PR DESCRIPTION
abort if the file doesnt open, and remove the QJsonParseError because the fromBinary function doesnt use it, and both fromBinary and fromJson will return a null jsonDoc if the load fails.