### PR TITLE
ignore possible appendixes from content type

### DIFF
--- a/jobs/basejob.cpp
+++ b/jobs/basejob.cpp
@@ -282,9 +282,12 @@ bool checkContentType(const QByteArray& type, const QByteArrayList& patterns)
     if (patterns.isEmpty())
         return true;
 
+    // ignore possible appendixes of the content type
+    const auto ctype = type.split(';').front();
+
     for (const auto& pattern: patterns)
     {
-        if (pattern.startsWith('*') || type == pattern) // Fast lane
+        if (pattern.startsWith('*') || ctype == pattern) // Fast lane
             return true;
 
         auto patternParts = pattern.split('/');
@@ -292,7 +295,7 @@ bool checkContentType(const QByteArray& type, const QByteArrayList& patterns)
             "BaseJob: Expected content type should have up to two"
             " /-separated parts; violating pattern: " + pattern);
 
-        if (type.split('/').front() == patternParts.front() &&
+        if (ctype.split('/').front() == patternParts.front() &&
                 patternParts.back() == "*")
             return true; // Exact match already went on fast lane
     }


### PR DESCRIPTION
Currently libqmatrixclient fails checking the content type header when there is an appendix like "charset"(which is allowed e.g. in [rfc7231](https://tools.ietf.org/html/rfc7231#section-3.1.1.5))

One example is a Content-Type `application/json` vs `application/json;charset=UTF-8`
Setting of the charset appendis is currently not supported. It fails with
libqmatrixclient.jobs: "LoginJob" status 106 : "Incorrect content type of the response"

This PR aims to just drop that appendix as it is currently not handled somewhere else.