### PR TITLE
Fix compilation issue of qmc-example.

### DIFF
--- a/qmc-example.pro
+++ b/qmc-example.pro
@@ -1,5 +1,7 @@
 TEMPLATE = app
 
+CONFIG += object_parallel_to_source
+
 windows { CONFIG += console }
 
 include(libqmatrixclient.pri)


### PR DESCRIPTION
Currently (at least on my computer with qmake, gcc 8.1.1 and Fedora 28) qmc-example cannot be built because of the duplication of user.cpp in lib/user.cpp and lib/application-service/definitions/user.cpp. It will show the warning "overriding recipe for target 'user.o'" and the build will fail.

This merge is intended to solve this issue by forcing QMake recreate source folder tree for object files.