### PR TITLE
Remove default avatar.

### DIFF
--- a/lib/avatar.h
+++ b/lib/avatar.h
@@ -31,8 +31,8 @@ namespace QMatrixClient
     class Avatar
     {
         public:
-            explicit Avatar(QIcon defaultIcon = {});
-            explicit Avatar(QUrl url, QIcon defaultIcon = {});
+            explicit Avatar();
+            explicit Avatar(QUrl url);
             Avatar(Avatar&&);
             ~Avatar();
             Avatar& operator=(Avatar&&);

--- a/lib/user.cpp
+++ b/lib/user.cpp
@@ -44,9 +44,7 @@ class User::Private
     public:
         static Avatar makeAvatar(QUrl url)
         {
-            static const QIcon icon
-                { QIcon::fromTheme(QStringLiteral("user-available")) };
-            return Avatar(move(url), icon);
+            return Avatar(move(url));
         }
 
         Private(QString userId, Connection* connection)


### PR DESCRIPTION
Fixes #241 .
I tested it and it seemed working. Nonetheless more tests are needed.
Also, no more "QImage::scaled: Image is a null image" error.