### PR TITLE
add http2 and pipelining for all Jobs

### DIFF
--- a/lib/jobs/basejob.cpp
+++ b/lib/jobs/basejob.cpp
@@ -204,6 +204,11 @@ void BaseJob::Private::sendRequest(bool inBackground)
     req.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
     req.setMaximumRedirectsAllowed(10);
 #endif
+    req.setAttribute(QNetworkRequest::HttpPipeliningAllowedAttribute, true);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 9, 0)
+    // some sources claim that there are issues with QT 5.8
+    req.setAttribute(QNetworkRequest::HTTP2AllowedAttribute, true);
+#endif
     for (auto it = requestHeaders.cbegin(); it != requestHeaders.cend(); ++it)
         req.setRawHeader(it.key(), it.value());
     switch( verb )


### PR DESCRIPTION
To speedup processing enable those two attributes.

HTTP/2 is implemented in QT in a way that it will fallback to HTTP/1.1 if the server does not support it and
Pipelining is quite old so that all servers should support it => I don't expect an issue because of that as well