### PR TITLE
changed header installation path to subfolder 'QMatrixClient'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ set_property(TARGET QMatrixClient APPEND PROPERTY
 
 target_include_directories(QMatrixClient PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lib>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/QMatrixClient>
 )
 target_link_libraries(QMatrixClient Qt5::Core Qt5::Network Qt5::Gui)
 
@@ -163,9 +163,9 @@ configure_file(QMatrixClient.pc.in ${CMAKE_CURRENT_BINARY_DIR}/QMatrixClient.pc 
 install(TARGETS QMatrixClient EXPORT QMatrixClientTargets
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/QMatrixClient
 )
-install(DIRECTORY lib/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+install(DIRECTORY lib/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/QMatrixClient
         FILES_MATCHING PATTERN "*.h")
 
 include(CMakePackageConfigHelpers)

--- a/QMatrixClient.pc.in
+++ b/QMatrixClient.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/QMatrixClient
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 
 Name: QMatrixClient


### PR DESCRIPTION
changing header installation path to subfolder `QMatrixClient` results in a cleaner system wide installation, e.g. `/usr/local/include/QMatrixClient` instead of just`/usr/local/include`
This also avoids possible naming conflicts with other system wide installed packages.

CMake and pkgconfig based projects don't need any changes. Other projects might need to change the include path to `<prefix>/include/QMatrixClient`



