### PR TITLE
added option for installation of qmc-example application

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.1)
 
 project(qmatrixclient CXX)
 
+option(QMATRIXCLIENT_INSTALL_EXAMPLE "install qmc-example application" ON)
+
 include(CheckCXXCompilerFlag)
 if (NOT WIN32)
     include(GNUInstallDirs)
@@ -198,7 +200,9 @@ if (WIN32)
     install(FILES mime/packages/freedesktop.org.xml DESTINATION mime/packages)
 endif (WIN32)
 
-install(TARGETS qmc-example RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+if (QMATRIXCLIENT_INSTALL_EXAMPLE)
+    install(TARGETS qmc-example RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif (QMATRIXCLIENT_INSTALL_EXAMPLE)
 
 if (UNIX AND NOT APPLE)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/QMatrixClient.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)


### PR DESCRIPTION
added option to avoid installation of `qmc-example` by passing `-DQMATRIXCLIENT_INSTALL_EXAMPLE=OFF` to `cmake`

The example is usually not needed in "production" environment. 