### PR TITLE
Refactor Connection::SupportedRoomVersion debug operators

### DIFF
--- a/lib/connection.h
+++ b/lib/connection.h
@@ -266,20 +266,11 @@ namespace QMatrixClient
                 static const QString StableTag; // "stable", as of CS API 0.5
                 bool isStable() const { return status == StableTag; }
 
-                // Pretty-printing
-
                 friend QDebug operator<<(QDebug dbg,
                                          const SupportedRoomVersion& v)
                 {
                     QDebugStateSaver _(dbg);
                     return dbg.nospace() << v.id << '/' << v.status;
-                }
-
-                friend QDebug operator<<(QDebug dbg,
-                                         const QVector<SupportedRoomVersion>& vs)
-                {
-                    return QtPrivate::printSequentialContainer(
-                                dbg, "", vs);
                 }
             };
 


### PR DESCRIPTION
Do not rely on a Qt private API and fix compilation for Qt < 5.7.

Closes #284

Note: The debug print is changed from
```
("my_id1"/"my_status1", "my_id2"/"my_status2")
```
to
```
QVector("my_id1"/"my_status1", "my_id2"/"my_status2")
```
for the sake of Private being kept in private.
